### PR TITLE
Improve performance of household matching 

### DIFF
--- a/households/matching.py
+++ b/households/matching.py
@@ -2,13 +2,15 @@ import textdistance
 import usaddress
 import pandas as pd
 import numpy as np
+import recordlinkage
+
 from recordlinkage.base import BaseCompareFeature
 
 
-MATCH_THRESHOLD = 0.7
+MATCH_THRESHOLD = 0.8
 FN_WEIGHT = 0.2
-PHONE_WEIGHT = 0.2
-ADDR_WEIGHT = 0.3
+PHONE_WEIGHT = 0.15
+ADDR_WEIGHT = 0.35
 ZIP_WEIGHT = 0.3
 
 
@@ -221,7 +223,7 @@ def address_distance(a1, a2):
     return score
 
 
-# see https://github.com/J535D165/recordlinkage/blob/master/recordlinkage/compare.py
+# https://github.com/J535D165/recordlinkage/blob/master/recordlinkage/compare.py
 class AddressComparison(BaseCompareFeature):
     """Compare the record pairs as Addresses.
     This class is used to compare records using custom address-based logic.
@@ -257,18 +259,61 @@ class AddressComparison(BaseCompareFeature):
         c = conc.apply(comp_address_apply)
         return c
 
-def match_households(already_added, pat_clks, pat_ids, line, pii_lines):
-    for position, line_compare in enumerate(pii_lines):
-        if position in already_added:
-            continue
-        weighted_fn = textdistance.jaro_winkler(line[2], line_compare[2]) * FN_WEIGHT
-        weighted_phone = textdistance.jaro_winkler(line[5], line_compare[5]) * PHONE_WEIGHT
-        weighted_addr = address_distance(line[6], line_compare[6]) * ADDR_WEIGHT
-        weighted_zip = (
-            textdistance.hamming.normalized_similarity(line[7], line_compare[7]) * ZIP_WEIGHT
-        )
-        total_distance = weighted_fn + weighted_zip + weighted_addr + weighted_phone
-        if total_distance > MATCH_THRESHOLD:
-            pat_clks.append(position)
-            pat_ids.append(line_compare[0])
-            already_added.append(position)
+
+def get_houshold_matches(pii_lines):
+    # indexing step defines the pairs of records for comparison
+    # indexer.all() does a full n^2 comparison, but we can do better
+    indexer = recordlinkage.Index()
+    # use sorted naighborhood here to allow for typos and close matches:
+    # "This algorithm returns record pairs that agree on the sorting key,
+    #  but also records pairs in their neighbourhood."
+    # potentially match on close zips and street names
+    # note that the default "window" aka distance to consider pairs is 3
+    indexer.sortedneighbourhood('household_zip')
+    indexer.sortedneighbourhood('street')
+    candidate_links = indexer.index(pii_lines)
+
+    # Comparison step performs the defined comparison algorithms
+    # against the candidate pairs
+    compare_cl = recordlinkage.Compare()
+
+    compare_cl.string('family_name', 'family_name',
+                      method='jarowinkler', label='family_name')
+    compare_cl.string('phone_number', 'phone_number',
+                      method='jarowinkler', label='phone_number')
+    compare_cl.add(AddressComparison('household_street_address',
+                                     'household_street_address',
+                                     label='household_street_address'))
+    compare_cl.string('household_zip', 'household_zip',
+                      method='levenshtein', label='household_zip')
+    # note: hamming distance is not implemented in this library,
+    # but levenshtein is. the two metrics are likely similar enough
+    # that it's not worth implementing hamming again
+
+    features = compare_cl.compute(candidate_links, pii_lines)
+
+    features['family_name'] *= FN_WEIGHT
+    features['phone_number'] *= PHONE_WEIGHT
+    features['household_street_address'] *= ADDR_WEIGHT
+    features['household_zip'] *= ZIP_WEIGHT
+
+    # filter the matches down based on the cumulative score
+    matches = features[features.sum(axis=1) > MATCH_THRESHOLD]
+
+    matching_pairs = list(matches.index)
+    # matching pairs are bi-directional and not duplicated,
+    # ex if (1,9) is in the list then (9,1) won't be
+
+    pos_to_pairs = {}
+    for pair in matching_pairs:
+        if pair[0] in pos_to_pairs:
+            pos_to_pairs[pair[0]].append(pair)
+        else:
+            pos_to_pairs[pair[0]] = [pair]
+
+        if pair[1] in pos_to_pairs:
+            pos_to_pairs[pair[1]].append(pair)
+        else:
+            pos_to_pairs[pair[1]] = [pair]
+
+    return pos_to_pairs

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ textdistance>=4.2.1
 usaddress>=0.5.10
 pylint>=2.4.2
 tqdm>=4.36.1
+pandas>=1.2.1
+recordlinkage>=0.14

--- a/testing-and-tuning/build_key.py
+++ b/testing-and-tuning/build_key.py
@@ -1,0 +1,67 @@
+import csv
+import json
+from pathlib import Path
+
+# This script creates the site-specific answer key CSVs out of the overall answer_key JSON.
+# It iterates over the json and breaks out people based on which site they belong to.
+# The columns of the CSV are just the 4 fields from the objects in the JSON.
+# Note that nothing actually uses the file_name so it could be stripped for file size if necessary.
+
+answer_key = Path("../temp-data/answer_key.json")
+
+sites = ['a', 'b', 'c', 'd', 'e', 'f']
+site_ids = {}
+for site in sites:
+    site_ids[site] = set()
+    pii_file = Path(f"../temp-data/pii_site_{site}.csv")
+    with open(pii_file) as pii_csv:
+        pii_reader = csv.reader(pii_csv)
+        # Skips header
+        next(pii_reader)
+        for row in pii_reader:
+            site_ids[site].add(row[0])
+
+HEADER = ["record_id", "seed_record_id", "household_id", "file_name"]
+new_answer_key = []
+with open(answer_key) as f:
+    d = json.load(f)
+    
+    # {
+    #   "14444032-081e-92ac-47dd-eafdbce66365": [
+    #     {
+    #       "record_id": "19029",
+    #       "seed_record_id": "19028",
+    #       "household_id": "3879064",
+    #       "file_name": "Andrew_Nikla_Denbraber_14444032-081e-92ac-47dd-eafdbce663652.json"
+    #     },
+    #     {
+    #       "record_id": "19030",
+    #       "seed_record_id": "19028",
+    #       "household_id": "3879064",
+    #       "file_name": "Dr_Andrew_Denbraber_14444032-081e-92ac-47dd-eafdbce663650.json"
+    #     },
+    #     {
+    #       "record_id": "19029",
+    #       "seed_record_id": "19028",
+    #       "household_id": "3879064",
+    #       "file_name": "Andrew_Nikla_Denbraber_14444032-081e-92ac-47dd-eafdbce663651.json"
+    #     }
+    #   ],
+    
+    for household in d.values():
+        for record in household:
+            record_id = record['record_id']
+            seed_record_id = record['seed_record_id']
+            household_id = record['household_id']
+            file_name = record['file_name']
+            key_line = [record_id, seed_record_id, household_id, file_name]
+            new_answer_key.append(key_line)
+
+for site in sites:
+    csv_out_path = Path(f"../temp-data/site_{site}_key.csv")
+    with open(csv_out_path, "w", newline="", encoding="utf-8") as answer_key_csv:
+        writer = csv.writer(answer_key_csv)
+        writer.writerow(HEADER)
+        for output_row in new_answer_key:
+            if output_row[0] in site_ids[site]:
+                writer.writerow(output_row)

--- a/testing-and-tuning/hh_all_sites.sh
+++ b/testing-and-tuning/hh_all_sites.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Script to run through all sites, group by households, and score the results.
+
+# Note this script expects to be run from the root data-owner-tools folder, i.e.,
+# ./testing-and-tuning/hh_all_sites.sh
+
+# Required files in temp_data:
+# - pii_site_*.csv -- obtained by extract.py
+# - site_*_key.csv -- obtained by build_key.py
+
+SITES="a b c d e f"
+for s in $SITES
+do
+  echo running site_$s
+  python3 households.py -t temp-data/pii_site_${s}.csv deidentification_secret.txt
+  mv temp-data/household_pos_pid.csv temp-data/site_${s}_household_pos_pid.csv
+  mv temp-data/hh_pos_patids.csv temp-data/site_${s}_hh_pos_patids.csv
+done
+
+cd testing-and-tuning
+
+python3 answer_key_map.py
+
+python3 hh_score.py

--- a/testing-and-tuning/hh_score.py
+++ b/testing-and-tuning/hh_score.py
@@ -4,55 +4,58 @@ import csv
 from itertools import combinations
 from pathlib import Path
 
-true_positives = 0
-false_positives = 0
 
-hid_csv_path = Path("../temp-data/hh_pos_patids.csv")
-key_csv_path = Path("../temp-data/site_f_key.csv")
-map_csv_path = Path("../temp-data/site_f_hid_mapping.csv")
+sites = ['a', 'b', 'c', 'd', 'e', 'f']
 
-answer_key_dict = {}
-mapping_dict = {}
-hpos_pid_dict = {}
-result_dict = {}
-household_answer_count = 0
+for site in sites:
+    hid_csv_path = Path(f"../temp-data/site_{site}_hh_pos_patids.csv")
+    key_csv_path = Path(f"../temp-data/site_{site}_key.csv")
+    map_csv_path = Path(f"../temp-data/site_{site}_hid_mapping.csv")
 
-with open(key_csv_path) as key_csv:
-    key_reader = csv.reader(key_csv)
-    # Skips header
-    next(key_reader)
-    for row in key_reader:
-        household_answer_count += 1
-        answer_key_dict[row[2]] = row[0]
+    answer_key = set()
+    mapping_dict = {}
+    hpos_pid_dict = {}
+    result_dict = {}
+    true_positives = 0
+    false_positives = 0
 
-with open(hid_csv_path) as hid_csv:
-    hid_reader = csv.reader(hid_csv)
-    # Skips header
-    next(hid_reader)
-    for row in hid_reader:
-        hpos_pid_dict[row[0]] = row[1]
+    with open(key_csv_path) as key_csv:
+        key_reader = csv.reader(key_csv)
+        # Skips header
+        next(key_reader)
+        for row in key_reader:
+            hid = row[2]
+            pid = row[0]
+            answer_key.add((pid, hid))
 
-with open(map_csv_path) as map_csv:
-    map_reader = csv.reader(map_csv)
-    # Skips header
-    next(map_reader)
-    for row in map_reader:
-        mapping_dict[row[0]] = row[1]
+    with open(hid_csv_path) as hid_csv:
+        hid_reader = csv.reader(hid_csv)
+        # Skips header
+        next(hid_reader)
+        for row in hid_reader:
+            hpos_pid_dict[row[0]] = row[1]  # household_pos --> patient_id
 
-for hpos, pid in hpos_pid_dict.items():
-    if hpos in mapping_dict:
-        hid = mapping_dict[hpos]
-        if hid in answer_key_dict:
-            if answer_key_dict[hid] == pid:
+    with open(map_csv_path) as map_csv:
+        map_reader = csv.reader(map_csv)
+        # Skips header
+        next(map_reader)
+        for row in map_reader:
+            mapping_dict[row[0]] = row[1]  # household_pos --> household_id
+
+    for hpos, pid in hpos_pid_dict.items():
+        if hpos in mapping_dict:
+            hid = mapping_dict[hpos]
+
+            if (pid, hid) in answer_key:
                 true_positives += 1
             else:
                 false_positives += 1
 
-precision = true_positives / (true_positives + false_positives)
-recall = true_positives / household_answer_count
-fscore = 2 * ((precision * recall) / (precision + recall))
-print(
-    "Data owner household linkage scoring:\nPrecision: {} Recall: {} F-Score: {}".format(
-        precision, recall, fscore
+    precision = true_positives / (true_positives + false_positives)
+    recall = true_positives / len(answer_key)
+    fscore = 2 * ((precision * recall) / (precision + recall))
+    print(
+        "Site {} Data owner household linkage scoring:\nPrecision: {} Recall: {} F-Score: {}".format(
+            site, precision, recall, fscore
+        )
     )
-)


### PR DESCRIPTION
This PR replaces the the current N^2 implementation of household matching and introduces the Python Record Linkage Toolkit ( https://github.com/J535D165/recordlinkage ) in order to greatly reduce the runtime. Anecdotally this reduces the runtime of a single site within the Synthetic Denver sample data from around 45 seconds to around 8 seconds. There may be opportunity for further speedup as well.

This approach basically follows the "data deduplication" flow from the Toolkit:
 - create a list of candidate pairs
   - in this case using address and zip code to quickly find "close enough" matches that are worth a more detailed matching process
 - define a set of characteristics to match against
   - family name
   - phone number
   - household street address
   - household zip
 - evaluate all the candidate pairs to produce a numerical score of similarity
 - filter the candidate pairs by some match threshold

Then those final filtered pairs are processed to produce the same outputs as the previous impl.

Note I also made a couple tweaks to the match algorithm weights based on testing with the Synthetic Denver sample data, and these seem to have improved both the precision and recall of the algorithm:
 - increased the overall match threshold from 0.7 to 0.8, this reduced false positives significantly
 - moved some weight from phone number to address, this reduced false negatives (assuming that over time people are more likely to have personal cell phones vs a single home phone within a household, and the address is the most important field to match on)
