### PR TITLE
Security improvements

### DIFF
--- a/derive_subkey.py
+++ b/derive_subkey.py
@@ -1,0 +1,10 @@
+import hmac
+import hashlib
+
+
+def derive_subkey(secret, context):
+    if context not in ["individuals", "households"]:
+        raise ValueError("Invalid subkey context: Use 'individuals' or 'households'")
+
+    h = hmac.new(str.encode(secret), str.encode(context), hashlib.sha256)
+    return h.hexdigest()

--- a/garble.py
+++ b/garble.py
@@ -38,8 +38,12 @@ def validate_secret_file(secret_file):
     secret = None
     with open(secret_file, "r") as secret_text:
         secret = secret_text.read()
-        if len(secret) < 256:
-            sys.exit("Secret length not long enough to ensure proper de-identification")
+        try:
+            int(secret, 16)
+        except ValueError:
+            sys.exit('Secret must be in hexadecimal format')
+        if len(secret) < 32:
+            sys.exit('Secret smaller than minimum security level')
     return secret
 
 

--- a/garble.py
+++ b/garble.py
@@ -53,7 +53,7 @@ def garble_pii(args):
     source_file = args.sourcefile
     os.makedirs('output', exist_ok=True)
     secret = validate_secret_file(secret_file)
-    individuals_secret = derive_subkey(secret, 'households')
+    individuals_secret = derive_subkey(secret, 'individuals')
 
     clk_files = []
     schema = glob.glob(args.schemadir + "/*.json")

--- a/garble.py
+++ b/garble.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from zipfile import ZipFile
 
+from derive_subkey import derive_subkey
+
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
@@ -47,6 +49,8 @@ def garble_pii(args):
     source_file = args.sourcefile
     os.makedirs('output', exist_ok=True)
     secret = validate_secret_file(secret_file)
+    individuals_secret = derive_subkey(secret, 'households')
+
     clk_files = []
     schema = glob.glob(args.schemadir + "/*.json")
     for s in schema:
@@ -58,8 +62,15 @@ def garble_pii(args):
                     + str(s)
                 )
         output_file = Path(args.outputdir, s.split('/')[-1])
-        completed_process = subprocess.run(
-            ["anonlink", "hash", source_file, secret, str(s), str(output_file)],
+        subprocess.run(
+            [
+                "anonlink",
+                "hash",
+                source_file,
+                individuals_secret,
+                str(s),
+                str(output_file)
+            ],
             check=True
         )
         clk_files.append(output_file)

--- a/households.py
+++ b/households.py
@@ -10,6 +10,7 @@ from zipfile import ZipFile
 
 import pandas as pd
 
+from derive_subkey import derive_subkey
 from households.matching import addr_parse, get_houshold_matches
 
 HEADERS = ["HOUSEHOLD_POSITION", "PAT_CLK_POSITIONS"]
@@ -191,6 +192,7 @@ def hash_households(args):
     schema_file = Path(args.schemafile)
     secret_file = Path(args.secretfile)
     secret = validate_secret_file(secret_file)
+    households_secret = derive_subkey(secret, 'households')
     with open(schema_file, "r") as schema:
         file_contents = schema.read()
         if "doubleHash" in file_contents:
@@ -204,7 +206,7 @@ def hash_households(args):
             "anonlink",
             "hash",
             "temp-data/households_pii.csv",
-            secret,
+            households_secret,
             str(schema_file),
             str(output_file),
         ]

--- a/households.py
+++ b/households.py
@@ -4,6 +4,7 @@ import argparse
 import csv
 import os
 from pathlib import Path
+from random import shuffle
 import subprocess
 import sys
 from zipfile import ZipFile
@@ -95,6 +96,7 @@ def parse_source_file(source_file):
 
 
 def write_households_pii(output_rows):
+    shuffle(output_rows)
     with open(
         "temp-data/households_pii.csv", "w", newline="", encoding="utf-8"
     ) as house_csv:

--- a/households.py
+++ b/households.py
@@ -59,8 +59,12 @@ def validate_secret_file(secret_file):
     secret = None
     with open(secret_file, "r") as secret_text:
         secret = secret_text.read()
-        if len(secret) < 256:
-            sys.exit("Secret length not long enough to ensure proper de-identification")
+        try:
+            int(secret, 16)
+        except ValueError:
+            sys.exit('Secret must be in hexadecimal format')
+        if len(secret) < 32:
+            sys.exit('Secret smaller than minimum security level')
     return secret
 
 

--- a/testing-and-tuning/generate_secret.py
+++ b/testing-and-tuning/generate_secret.py
@@ -1,8 +1,7 @@
 from secrets import token_hex
 
-secret_bit_length = 128
-
-deidentification_secret = token_hex(secret_bit_length)
+# use 32 characters (1 character = 4 bits) for 128 bits of entropy
+deidentification_secret = token_hex(32)
 
 with open('deidentification_secret.txt', 'w', newline='') as secret_file:
   secret_file.write(deidentification_secret)

--- a/testing-and-tuning/hh_all_sites.sh
+++ b/testing-and-tuning/hh_all_sites.sh
@@ -2,12 +2,14 @@
 
 # Script to run through all sites, group by households, and score the results.
 
-# Note this script expects to be run from the root data-owner-tools folder, i.e.,
-# ./testing-and-tuning/hh_all_sites.sh
+# Note this script expects to be run from the testing-and-tuning folder, i.e.,
+# ./hh_all_sites.sh
 
 # Required files in temp_data:
 # - pii_site_*.csv -- obtained by extract.py
 # - site_*_key.csv -- obtained by build_key.py
+
+cd ..
 
 SITES="a b c d e f"
 for s in $SITES


### PR DESCRIPTION
This PR implements a set of improvements as recommended by cryptographic experts, to ensure that reidentification of CLKs within the household linkage is "very small".

Changes include:
 - Shuffling the rows of the households_pii.csv file to ensure that the ordering of the households is completely independent of the ordering of the individuals. 
 - Validating the secret is a hexadecimal string of at least length 32 characters, and reducing the helper script here to only generate a 32 character secret. (Previously we were generating 128 characters instead of the intended 128 bits, which at 4 bits/character is 32 characters. Also note that any existing 128 character hex strings generated by the previous impl are still valid, just longer than needed)
 - Deriving a subkey based on the secret, where garble.py and households.py each get a unique subkey.

I also took this opportunity to address a previous comment about the `testing-and-tuning/hh_all_sites.sh` script, so that now it's more consistent with other scripts in the same folder, and expects to be invoked from the testing-and-tuning folder rather than the root data-owner-tools folder.