### PR TITLE
README: update pip before installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ source venv/bin/activate
 #### Installing dependencies
 
 ```shell
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tools for Clinical and Community Data Initiative (CODI) data owners to extract p
 
 ### Dependency Overview
 
-These tools were created and tested on Python 3.7.4. The tools rely on two libraries: [SQLAlchemy](https://www.sqlalchemy.org/) and [anonlink](https://github.com/data61/anonlink).
+These tools were created and tested on Python 3.9.12. The tools rely on two libraries: [SQLAlchemy](https://www.sqlalchemy.org/) and [anonlink](https://github.com/data61/anonlink).
 
 SQLAlchemy is a library that allows the tools to connect to a database in a vendor independent fashion. This allows the tools to connect to a database that conforms to the CODI Identity Data Model implented in PostgreSQL or Microsoft SQLServer (and a number of others).
 


### PR DESCRIPTION
Update python version in README. Python 3.8+ is required to support `:=` walrus operator.

Adds a pip update step in the instructions. Packages like `cryptography` may require more recent versions of pip than a user has installed to install.

https://cryptography.io/en/latest/installation/

> You can install cryptography with pip:
> `pip install cryptography`
> If this does not work please upgrade your pip first, as that is the single most common cause of installation problems.