### PR TITLE
Garble: Handle Windows Style Pathnames

### DIFF
--- a/garble.py
+++ b/garble.py
@@ -101,7 +101,7 @@ def garble_pii(args):
                 sys.exit(
                     "The following schema uses doubleHash, which is insecure: " + str(s)
                 )
-        output_file = Path(args.outputdir, s.split("/")[-1])
+        output_file = Path(args.outputdir) / os.path.basename(s)
         subprocess.run(
             [
                 "anonlink",


### PR DESCRIPTION
Updates the PPRL Guardrails code to handle *nix and Windows style pathnames.

~Waiting to merge until we have confirmation from partner data-owner testing.~