### PR TITLE
`households.py` Includes metadata when creating garbled zip archive for household files

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -260,7 +260,7 @@ def write_metadata(n_rows, creation_time):
         "uuid1": str(uuid.uuid1()),
     }
     timestamp = datetime.strftime(creation_time, "%Y%m%dT%H%M%S")
-    metaname = f"temp-data/metadata-{timestamp}.json"
+    metaname = Path("temp-data") / f"metadata-{timestamp}.json"
     with open(metaname, "w", newline="", encoding="utf-8") as metafile:
         json.dump(metadata, metafile, indent=2)
 

--- a/extract.py
+++ b/extract.py
@@ -262,7 +262,7 @@ def write_metadata(n_rows, creation_time):
     timestamp = datetime.strftime(creation_time, "%Y%m%dT%H%M%S")
     metaname = f"temp-data/metadata-{timestamp}.json"
     with open(metaname, "w", newline="", encoding="utf-8") as metafile:
-        metafile.write(json.dumps(metadata))
+        json.dump(metadata, metafile, indent=2)
 
 
 def write_data(output_rows, args):

--- a/extract.py
+++ b/extract.py
@@ -8,6 +8,7 @@ import unicodedata
 import uuid
 from collections import Counter
 from datetime import datetime
+from pathlib import Path
 from random import shuffle
 from time import strftime, strptime
 

--- a/garble.py
+++ b/garble.py
@@ -88,7 +88,7 @@ def garble_pii(args):
         source_timestamp == meta_timestamp
     ), "Metadata creation date does not match pii file timestamp"
 
-    shutil.copyfile(metadata_file, f"output/{metadata_file_name}")
+    shutil.copyfile(metadata_file, Path("output") / metadata_file_name)
 
     secret = validate_secret_file(secret_file)
     individuals_secret = derive_subkey(secret, "individuals")
@@ -125,7 +125,7 @@ def create_output_zip(clk_files, args):
             garbled_zip.write(output_file)
             if "metadata" in output_file.name:
                 os.remove(output_file)
-    print("Zip file created at: " + args.outputdir + "/" + args.outputzip)
+    print("Zip file created at: " + str(Path(args.outputdir) / args.outputzip))
 
 
 def main():

--- a/households.py
+++ b/households.py
@@ -287,7 +287,7 @@ def create_output_zip(args, n_households):
 
     os.remove(Path("output") / metadata_file_name)
 
-    print("Zip file created at: " + args.outputfile)
+    print("Zip file created at: " + str(Path(args.outputfile)))
 
 
 def main():

--- a/households.py
+++ b/households.py
@@ -2,6 +2,7 @@
 
 import argparse
 import csv
+import json
 import os
 import subprocess
 import sys
@@ -152,7 +153,9 @@ def write_mapping_file(pos_pid_rows, hid_pat_id_rows, args):
     source_file = Path(args.sourcefile)
     pii_lines = parse_source_file(source_file)
     output_rows = []
-    with open(args.mappingfile, "w", newline="", encoding="utf-8") as csvfile:
+    mapping_file = Path(args.mappingfile)
+    n_households = 0
+    with open(mapping_file, "w", newline="", encoding="utf-8") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(HEADERS)
         already_added = set()
@@ -181,6 +184,7 @@ def write_mapping_file(pos_pid_rows, hid_pat_id_rows, args):
             string_pat_clks = [str(int) for int in pat_clks]
             pat_string = ",".join(string_pat_clks)
             writer.writerow([hclk_position, pat_string])
+            n_households += 1
             pos_pid_rows.append([hclk_position, line[0]])
             for patid in pat_ids:
                 hid_pat_id_rows.append([hclk_position, patid])
@@ -189,7 +193,7 @@ def write_mapping_file(pos_pid_rows, hid_pat_id_rows, args):
             output_row = [line[2], line[5], line[6], line[7], pat_ids_str]
             hclk_position += 1
             output_rows.append(output_row)
-    return output_rows
+    return output_rows, n_households
 
 
 def write_scoring_file(hid_pat_id_rows):
@@ -243,27 +247,57 @@ def hash_households(args):
 def infer_households(args):
     pos_pid_rows = []
     hid_pat_id_rows = []
-    os.makedirs("output/households", exist_ok=True)
+    os.makedirs(Path("output") / "households", exist_ok=True)
     os.makedirs("temp-data", exist_ok=True)
-    output_rows = write_mapping_file(pos_pid_rows, hid_pat_id_rows, args)
+    output_rows, n_households = write_mapping_file(pos_pid_rows, hid_pat_id_rows, args)
     write_households_pii(output_rows)
     if args.testrun:
         write_scoring_file(hid_pat_id_rows)
         write_hid_hh_pos_map(pos_pid_rows)
+    return n_households
 
 
-def create_clk_zip(args):
-    with ZipFile(args.outputfile, "w") as garbled_zip:
-        garbled_zip.write("output/households/fn-phone-addr-zip.json")
+def create_output_zip(args, n_households):
+
+    source_file = Path(args.sourcefile)
+
+    source_file_name = os.path.basename(source_file)
+    source_dir_name = os.path.dirname(source_file)
+
+    source_timestamp = os.path.splitext(source_file_name.replace("pii-", ""))[0]
+    metadata_file_name = source_file_name.replace("pii", "metadata").replace(
+        ".csv", ".json"
+    )
+    metadata_file = Path(source_dir_name) / metadata_file_name
+    with open(metadata_file, "r") as fp:
+        metadata = json.load(fp)
+    meta_timestamp = metadata["creation_date"].replace("-", "").replace(":", "")[:-7]
+    assert (
+            source_timestamp == meta_timestamp
+    ), "Metadata creation date does not match pii file timestamp"
+
+    metadata["number_of_households"] = n_households
+
+    with open(Path("output") / metadata_file_name, "w") as metadata_file:
+        json.dump(metadata, metadata_file)
+
+    with ZipFile(Path(args.outputfile), "w") as garbled_zip:
+        garbled_zip.write(Path("output") / "households" / "fn-phone-addr-zip.json")
+        garbled_zip.write(Path("output") / metadata_file_name)
+
+    os.remove(Path("output") / metadata_file_name)
+
     print("Zip file created at: " + args.outputfile)
 
 
 def main():
     args = parse_arguments()
     if not args.householddef:
-        infer_households(args)
+        n_households = infer_households(args)
+    else:
+        n_households = 0
     hash_households(args)
-    create_clk_zip(args)
+    create_output_zip(args, n_households)
 
 
 if __name__ == "__main__":

--- a/households.py
+++ b/households.py
@@ -273,7 +273,7 @@ def create_output_zip(args, n_households):
         metadata = json.load(fp)
     meta_timestamp = metadata["creation_date"].replace("-", "").replace(":", "")[:-7]
     assert (
-            source_timestamp == meta_timestamp
+        source_timestamp == meta_timestamp
     ), "Metadata creation date does not match pii file timestamp"
 
     metadata["number_of_households"] = n_households


### PR DESCRIPTION
Also puts number of households in metadata file as something that can additionally be checked.