### PR TITLE
Added default `sourcefile` behavior to `garble.py` and `households.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ Any aberrant results should be investigated rectified within the data set before
 
 anonlink will garble personally identifiable information (PII) in a way that it can be used for linkage later on. The CODI PPRL process garbles information a number of different ways. The `garble.py` script will manage executing anonlink multiple times and package the information for transmission to the linkage agent.
 
-`garble.py` requires 2 different inputs:
-1. The location of a CSV file containing the PII to garble
-1. The location of a directory of anonlink linkage schema files
-1. The location of a secret file to use in the garbling process - this should be a text file containing a single hexadecimal string of at least 128 bits (32 characters); the `testing-and-tuning/generate_secret.py` script will create this for you if require it, e.g.:
+`garble.py` accepts the following positional inputs:
+1. (optional) The location of a CSV file containing the PII to garble. If not provided, the script will look for the newest `pii-TIMESTAMP.csv` file in the `temp-data` directory.
+1. (required) The location of a directory of anonlink linkage schema files
+1. (required)  The location of a secret file to use in the garbling process - this should be a text file containing a single hexadecimal string of at least 128 bits (32 characters); the `testing-and-tuning/generate_secret.py` script will create this for you if require it, e.g.:
 ```
 python testing-and-tuning/generate_secret.py
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Tools for Clinical and Community Data Initiative (CODI) data owners to extract p
 1. [Extract PII](#extract-pii)
 1. [Garbling](#garbling-pii)
 1. [Mapping LINKIDs to PATIDs](#mapping-linkids-to-patids)
-1. [Verifying Result Metadata](#verify-result-metadata)
 1. [Additional Information for Developer Testing and Tuning](#developer-testing)
 1. [Notice](#notice)
 
@@ -283,26 +282,28 @@ To map the LINK_IDs back to PATIDs, use the `linkid_to_patid.py` script. The scr
 
 1. The path to the pii-timestamp.csv file. 
 2. The path to the LINK_ID CSV file provided by the linkage agent
-3. The path to the Household pii-timestamp.csv file, either provided by the data owner directly or inferred by the `households.py` script
+3. The path to the household pii CSV file, either provided by the data owner directly or inferred by the `households.py` script (which by default is named `household_pii-timestamp.csv`)
 4. The path to the HOUSEHOLDID CSV file provided by the linkage agent if you provided household information
 
 If both the pii-timestamp.csv and LINK_ID CSV file are provided as arguments, the script will create a file called `linkid_to_patid.csv` with the mapping of LINK_IDs to PATIDs in the `output/` folder by default. If both the household pii-timestamp.csv and LINK_ID CSV file are provided as arguments this will also create a `householdid_to_patid.csv` file in the `output/` folder.
+
+### [Optional] Independently Validate Result Metadata
+
+The metadata created by the garbling process is used to validate the metadata returned by the linkage agent within the `linkid_to_patid.py` script. Additionally, the metadata returned by the linkage agents can be validated outside of the `linkid_to_patid.py` script using the `validate_metadata.py` script in the `utils` directory. The syntax from the root directory is 
+```
+python utils\validate_metadata.py <path-to-garbled.zip> <path-to-result.zip>
+```
+So, assuming that the output of `garble.py` is a file, `garble.zip` located in the `output` directory, and assuming that the results from the linkage agent are received as a zip archive named `results.zip` located in the `inbox` directory, the syntax would be
+```
+python utils\validate_metadata.py output\garble.py inbox\results.zip
+```
+By default, the script will only return the number of issues found during the validation process. Use the `-v` flag in order to print detailled information about each of the issues encountered during validation.
 
 ## Cleanup
 
 In between runs it is advisable to run `rm temp-data/*` to clean up temporary data files used for individuals runs.
 
-## Verify Result Metadata
 
-Once LINK_IDs have been received from the linkage agent, the metadata contained in the results archive can be compared to original garbled data with the `verify-linkage-metadata.py` script. The syntax is 
-```
-python verify-linkage-metadata.py <path-to-garbled.zip> <path-to-result.zip>
-```
-So, assuming that the output of `garble.py` is a file, `garble.zip` located in the `output` directory, and assuming that the results from the linkage agent are received as a zip archive named `results.zip` located in the `inbox` directory, the syntax would be
-```
-python verify-linkage-metadata.py output\garble.py inbox\results.zip
-```
-By default, the script will only return the number of issues found during the validation process. Use the `-v` flag in order to print detailled information about each of the issues encountered during validation.
 
 ## Developer Testing
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Any aberrant results should be investigated rectified within the data set before
 
 anonlink will garble personally identifiable information (PII) in a way that it can be used for linkage later on. The CODI PPRL process garbles information a number of different ways. The `garble.py` script will manage executing anonlink multiple times and package the information for transmission to the linkage agent.
 
-`garble.py` requires 3 different inputs:
+`garble.py` requires 2 different inputs:
 1. The location of a CSV file containing the PII to garble
 1. The location of a directory of anonlink linkage schema files
 1. The location of a secret file to use in the garbling process - this should be a text file containing a single hexadecimal string of at least 128 bits (32 characters); the `testing-and-tuning/generate_secret.py` script will create this for you if require it, e.g.:
@@ -184,7 +184,7 @@ python testing-and-tuning/generate_secret.py
 ```
 This should create a new file called deidentification_secret.txt in your root directory.
 
-`garble.py` requires that the location of the PII file, schema directory, and secret file are provided via positional arguments.
+`garble.py` requires that the location of the PII file, schema directory, and secret file are provided via positional arguments. If only two positional arguments are given, `garble.py` will use them as the schema directory and secret file locations, and will look for the newest `pii-TIMESTAMP.csv` file in the `temp-data` directory.
 
 The [anonlink schema files](https://anonlink-client.readthedocs.io/en/latest/schema.html) specify the fields that will be used in the hashing process as well as assigning weights to those fields. The `example-schema` directory contains a set of example schema that can be used to test the tools.
 
@@ -209,10 +209,20 @@ optional arguments:
 
 `garble.py` will package up the garbled PII files into a [zip file](https://en.wikipedia.org/wiki/Zip_(file_format)) called `garbled.zip` and place it in the `output/` folder by default, you can change this with an `--output` flag if desired.
 
-Example execution of `garble.py` is shown below:
+Two example executions of `garble.py` is shown below–first with the PII CSV specified via positional argument:
 
 ```
 $ python garble.py temp-data/pii-TIMESTAMP.csv example-schema ../deidentification_secret.txt
+CLK data written to output/name-sex-dob-phone.json
+CLK data written to output/name-sex-dob-zip.json
+CLK data written to output/name-sex-dob-parents.json
+CLK data written to output/name-sex-dob-addr.json
+Zip file created at: output/garbled.zip
+```
+And second without the PII CSV specified as a positional argument:
+```
+$ python garble.py example-schema ../deidentification_secret.txt
+PII Source: temp-data/pii-TIMESTAMP.csv
 CLK data written to output/name-sex-dob-phone.json
 CLK data written to output/name-sex-dob-zip.json
 CLK data written to output/name-sex-dob-parents.json
@@ -229,10 +239,16 @@ The households script will do the following:
 
 This information must be provided to the linkage agent if you would like to get a household linkages table as well.
 
-Example run:
+Example run with PII CSV specified:
 ```
 $ python households.py temp-data/pii-TIMESTAMP.csv ../deidentification_secret.txt
-Grouping individuals into households: 100%|███████████████████████| 819/819 [01:12<00:00, 11.37it/s]
+CLK data written to output/households/fn-phone-addr-zip.json
+Zip file created at: output/garbled_households.zip
+```
+and without PII CSV specified:
+```
+$ python households.py ../deidentification_secret.txt
+PII Source: temp-data/pii-TIMESTAMP.csv
 CLK data written to output/households/fn-phone-addr-zip.json
 Zip file created at: output/garbled_households.zip
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tools for Clinical and Community Data Initiative (CODI) data owners to extract p
 1. [Extract PII](#extract-pii)
 1. [Garbling](#garbling-pii)
 1. [Mapping LINKIDs to PATIDs](#mapping-linkids-to-patids)
+1. [Verifying Result Metadata](#verify-result-metadata)
 1. [Additional Information for Developer Testing and Tuning](#developer-testing)
 1. [Notice](#notice)
 
@@ -290,6 +291,18 @@ If both the pii-timestamp.csv and LINK_ID CSV file are provided as arguments, th
 ## Cleanup
 
 In between runs it is advisable to run `rm temp-data/*` to clean up temporary data files used for individuals runs.
+
+## Verify Result Metadata
+
+Once LINK_IDs have been received from the linkage agent, the metadata contained in the results archive can be compared to original garbled data with the `verify-linkage-metadata.py` script. The syntax is 
+```
+python verify-linkage-metadata.py <path-to-garbled.zip> <path-to-result.zip>
+```
+So, assuming that the output of `garble.py` is a file, `garble.zip` located in the `output` directory, and assuming that the results from the linkage agent are received as a zip archive named `results.zip` located in the `inbox` directory, the syntax would be
+```
+python verify-linkage-metadata.py output\garble.py inbox\results.zip
+```
+By default, the script will only return the number of issues found during the validation process. Use the `-v` flag in order to print detailled information about each of the issues encountered during validation.
 
 ## Developer Testing
 

--- a/README.md
+++ b/README.md
@@ -184,15 +184,13 @@ python testing-and-tuning/generate_secret.py
 ```
 This should create a new file called deidentification_secret.txt in your root directory.
 
-`garble.py` requires that the location of the PII file, schema directory, and secret file are provided via positional arguments. If only two positional arguments are given, `garble.py` will use them as the schema directory and secret file locations, and will look for the newest `pii-TIMESTAMP.csv` file in the `temp-data` directory.
-
 The [anonlink schema files](https://anonlink-client.readthedocs.io/en/latest/schema.html) specify the fields that will be used in the hashing process as well as assigning weights to those fields. The `example-schema` directory contains a set of example schema that can be used to test the tools.
 
 `garble.py`, and all other scripts in the repository, will provide usage information with the `-h` flag:
 
 ```
 $ python garble.py -h
-usage: garble.py [-h] [-o OUTPUTFILE] sourcefile schemadir secretfile
+usage: garble.py [-h] [-z OUTPUTZIP] [-o OUTPUTDIR] [sourcefile] schemadir secretfile
 
 Tool for garbling PII in for PPRL purposes in the CODI project
 
@@ -203,8 +201,10 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -o OUTPUTFILE, --output OUTPUTFILE
-                        Specify an output file. Default is output/garbled.zip
+  -z OUTPUTZIP, --outputzip OUTPUTZIP
+                        Specify an name for the .zip file. Default is garbled.zip
+  -o OUTPUTDIR, --outputdir OUTPUTDIR
+                        Specify an output directory. Default is output/
 ```
 
 `garble.py` will package up the garbled PII files into a [zip file](https://en.wikipedia.org/wiki/Zip_(file_format)) called `garbled.zip` and place it in the `output/` folder by default, you can change this with an `--output` flag if desired.
@@ -231,7 +231,7 @@ Zip file created at: output/garbled.zip
 ```
 ### [Optional] Household Extract and Garble
 
-You may now run `households.py` with the same arguments as the `garble.py` script, with the only difference being specifying a specific schema file instead of a schema directory - if no schema is specified it will default to the `example-schema/household-schema/fn-phone-addr-zip.json` (use `-h` flag for more information). NOTE: If you want to generate the testing and tuning files for development on a synthetic dataset, you need to specify the `-t` or `--testrun` flags
+You may now run `households.py` with the same arguments as the `garble.py` script, with the only difference being specifying a specific schema file instead of a schema directory - if no schema is specified it will default to the `example-schema/household-schema/fn-phone-addr-zip.json`. To specify a schemafile, it must be preceeded by the flag `--schemafile` (use `-h` flag for more information). NOTE: If you want to generate the testing and tuning files for development on a synthetic dataset, you need to specify the `-t` or `--testrun` flags
 
 The households script will do the following:
   1. Attempt to group individuals into households and store those records in a csv file in temp-data

--- a/garble.py
+++ b/garble.py
@@ -77,16 +77,15 @@ def garble_pii(args):
     if args.sourcefile:
         source_file = Path(args.sourcefile)
     else:
-        oldest_ts = datetime.fromtimestamp(0)
-        oldest_name = ""
-        for filename in filter(
+        filenames = list(filter(
             lambda x: "pii" in x and len(x) == 23, os.listdir("temp-data")
-        ):
-            timestamp = datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S")
-            if timestamp > oldest_ts:
-                oldest_name = filename
-                oldest_ts = timestamp
-        source_file = Path("temp-data") / oldest_name
+        ))
+        timestamps = [
+            datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S")
+            for filename in filenames
+        ]
+        newest_name = filenames[timestamps.index(max(timestamps))]
+        source_file = Path("temp-data") / newest_name
         print(f"PII Source: {str(source_file)}")
 
     os.makedirs("output", exist_ok=True)

--- a/garble.py
+++ b/garble.py
@@ -77,12 +77,11 @@ def garble_pii(args):
     if args.sourcefile:
         source_file = Path(args.sourcefile)
     else:
-        filenames = list(filter(
-            lambda x: "pii" in x and len(x) == 23, os.listdir("temp-data")
-        ))
+        filenames = list(
+            filter(lambda x: "pii" in x and len(x) == 23, os.listdir("temp-data"))
+        )
         timestamps = [
-            datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S")
-            for filename in filenames
+            datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S") for filename in filenames
         ]
         newest_name = filenames[timestamps.index(max(timestamps))]
         source_file = Path("temp-data") / newest_name

--- a/households.py
+++ b/households.py
@@ -121,7 +121,10 @@ def write_households_pii(output_rows, household_time):
     shuffle(output_rows)
     timestamp = household_time.strftime("%Y%m%dT%H%M%S")
     with open(
-        Path("temp-data") / f"households_pii-{timestamp}.csv", "w", newline="", encoding="utf-8"
+        Path("temp-data") / f"households_pii-{timestamp}.csv",
+        "w",
+        newline="",
+        encoding="utf-8",
     ) as house_csv:
         writer = csv.writer(house_csv)
         writer.writerow(HOUSEHOLD_PII_HEADERS)
@@ -201,7 +204,7 @@ def write_mapping_file(pos_pid_rows, hid_pat_id_rows, args):
 def write_scoring_file(hid_pat_id_rows):
     # Format is used for scoring
     with open(
-        Path("temp-data")/ "hh_pos_patids.csv", "w", newline="", encoding="utf-8"
+        Path("temp-data") / "hh_pos_patids.csv", "w", newline="", encoding="utf-8"
     ) as hpos_pat_csv:
         writer = csv.writer(hpos_pat_csv)
         writer.writerow(HOUSEHOLD_POS_PID_HEADERS)
@@ -234,7 +237,9 @@ def hash_households(args, household_time):
                 + str(schema_file)
             )
     output_file = Path("output") / "households" / "fn-phone-addr-zip.json"
-    household_pii_file = args.householddef or Path("temp-data") / f"households_pii-{timestamp}.csv"
+    household_pii_file = (
+        args.householddef or Path("temp-data") / f"households_pii-{timestamp}.csv"
+    )
     subprocess.run(
         [
             "anonlink",

--- a/households.py
+++ b/households.py
@@ -2,11 +2,11 @@
 
 import argparse
 import csv
-import datetime
 import json
 import os
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 from random import shuffle
 from zipfile import ZipFile
@@ -32,7 +32,9 @@ def parse_arguments():
         description="Tool for garbling household PII for PPRL purposes"
         " in the CODI project"
     )
-    parser.add_argument("sourcefile", help="Source PII CSV file")
+    parser.add_argument(
+        "sourcefile", default=None, nargs="?", help="Source pii-TIMESTAMP.csv file"
+    )
     parser.add_argument("secretfile", help="Location of de-identification secret file")
     parser.add_argument(
         "-d",
@@ -66,7 +68,7 @@ def parse_arguments():
         help="Optional generate files used for testing against an answer key",
     )
     args = parser.parse_args()
-    if not Path(args.sourcefile).exists():
+    if args.sourcefile and not Path(args.sourcefile).exists():
         parser.error("Unable to find source file: " + args.secretfile)
     if not Path(args.schemafile).exists():
         parser.error("Unable to find schema file: " + args.secretfile)
@@ -154,8 +156,24 @@ def bfs_traverse_matches(pos_to_pairs, position):
     return visited
 
 
+def get_default_pii_csv(dirname="temp-data"):
+    oldest_ts = datetime.fromtimestamp(0)
+    oldest_name = ""
+    for filename in filter(lambda x: "pii" in x and len(x) == 23, os.listdir(dirname)):
+        timestamp = datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S")
+        if timestamp > oldest_ts:
+            oldest_name = filename
+            oldest_ts = timestamp
+    source_file = Path("temp-data") / oldest_name
+    return source_file
+
+
 def write_mapping_file(pos_pid_rows, hid_pat_id_rows, args):
-    source_file = Path(args.sourcefile)
+    if args.sourcefile:
+        source_file = Path(args.sourcefile)
+    else:
+        source_file = get_default_pii_csv()
+        print(f"PII Source: {str(source_file)}")
     pii_lines = parse_source_file(source_file)
     output_rows = []
     mapping_file = Path(args.mappingfile)
@@ -269,7 +287,10 @@ def create_output_zip(args, n_households, household_time):
 
     timestamp = household_time.strftime("%Y%m%dT%H%M%S")
 
-    source_file = Path(args.sourcefile)
+    if args.sourcefile:
+        source_file = Path(args.sourcefile)
+    else:
+        source_file = get_default_pii_csv()
 
     source_file_name = os.path.basename(source_file)
     source_dir_name = os.path.dirname(source_file)
@@ -313,7 +334,7 @@ def create_output_zip(args, n_households, household_time):
 
 def main():
     args = parse_arguments()
-    household_time = datetime.datetime.now()
+    household_time = datetime.now()
     if not args.householddef:
         n_households = infer_households(args, household_time)
     else:

--- a/households.py
+++ b/households.py
@@ -2,6 +2,7 @@
 
 import argparse
 import csv
+import datetime
 import json
 import os
 import subprocess
@@ -116,10 +117,11 @@ def parse_source_file(source_file):
     return df
 
 
-def write_households_pii(output_rows):
+def write_households_pii(output_rows, household_time):
     shuffle(output_rows)
+    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
     with open(
-        "temp-data/households_pii.csv", "w", newline="", encoding="utf-8"
+        Path("temp-data") / f"households_pii-{timestamp}.csv", "w", newline="", encoding="utf-8"
     ) as house_csv:
         writer = csv.writer(house_csv)
         writer.writerow(HOUSEHOLD_PII_HEADERS)
@@ -199,7 +201,7 @@ def write_mapping_file(pos_pid_rows, hid_pat_id_rows, args):
 def write_scoring_file(hid_pat_id_rows):
     # Format is used for scoring
     with open(
-        "temp-data/hh_pos_patids.csv", "w", newline="", encoding="utf-8"
+        Path("temp-data")/ "hh_pos_patids.csv", "w", newline="", encoding="utf-8"
     ) as hpos_pat_csv:
         writer = csv.writer(hpos_pat_csv)
         writer.writerow(HOUSEHOLD_POS_PID_HEADERS)
@@ -210,7 +212,7 @@ def write_scoring_file(hid_pat_id_rows):
 def write_hid_hh_pos_map(pos_pid_rows):
     # Format is used for generating a hid to hh_pos for full answer key
     with open(
-        "temp-data/household_pos_pid.csv", "w", newline="", encoding="utf-8"
+        Path("temp-data") / "household_pos_pid.csv", "w", newline="", encoding="utf-8"
     ) as house_pos_csv:
         writer = csv.writer(house_pos_csv)
         writer.writerow(HOUSEHOLD_POS_PID_HEADERS)
@@ -218,7 +220,8 @@ def write_hid_hh_pos_map(pos_pid_rows):
             writer.writerow(output_row)
 
 
-def hash_households(args):
+def hash_households(args, household_time):
+    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
     schema_file = Path(args.schemafile)
     secret_file = Path(args.secretfile)
     secret = validate_secret_file(secret_file)
@@ -230,8 +233,8 @@ def hash_households(args):
                 "The following schema uses doubleHash, which is insecure: "
                 + str(schema_file)
             )
-    output_file = Path("output/households/fn-phone-addr-zip.json")
-    household_pii_file = args.householddef or "temp-data/households_pii.csv"
+    output_file = Path("output") / "households" / "fn-phone-addr-zip.json"
+    household_pii_file = args.householddef or Path("temp-data") / f"households_pii-{timestamp}.csv"
     subprocess.run(
         [
             "anonlink",
@@ -244,20 +247,22 @@ def hash_households(args):
     )
 
 
-def infer_households(args):
+def infer_households(args, household_time):
     pos_pid_rows = []
     hid_pat_id_rows = []
     os.makedirs(Path("output") / "households", exist_ok=True)
     os.makedirs("temp-data", exist_ok=True)
     output_rows, n_households = write_mapping_file(pos_pid_rows, hid_pat_id_rows, args)
-    write_households_pii(output_rows)
+    write_households_pii(output_rows, household_time)
     if args.testrun:
         write_scoring_file(hid_pat_id_rows)
         write_hid_hh_pos_map(pos_pid_rows)
     return n_households
 
 
-def create_output_zip(args, n_households):
+def create_output_zip(args, n_households, household_time):
+
+    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
 
     source_file = Path(args.sourcefile)
 
@@ -271,6 +276,8 @@ def create_output_zip(args, n_households):
     metadata_file = Path(source_dir_name) / metadata_file_name
     with open(metadata_file, "r") as fp:
         metadata = json.load(fp)
+
+    new_metadata_filename = f"households_metadata-{timestamp}.json"
     meta_timestamp = metadata["creation_date"].replace("-", "").replace(":", "")[:-7]
     assert (
         source_timestamp == meta_timestamp
@@ -278,26 +285,39 @@ def create_output_zip(args, n_households):
 
     metadata["number_of_households"] = n_households
 
-    with open(Path("output") / metadata_file_name, "w") as metadata_file:
-        json.dump(metadata, metadata_file)
+    if not args.householddef:
+        metadata["household_inference_time"] = household_time.isoformat()
+        metadata["households_inferred"] = True
+    else:
+        metadata["households_inferred"] = False
+
+    with open(Path("temp-data") / new_metadata_filename, "w") as metadata_file:
+        json.dump(metadata, metadata_file, indent=2)
+
+    with open(Path("output") / new_metadata_filename, "w") as metadata_file:
+        json.dump(metadata, metadata_file, indent=2)
 
     with ZipFile(Path(args.outputfile), "w") as garbled_zip:
         garbled_zip.write(Path("output") / "households" / "fn-phone-addr-zip.json")
-        garbled_zip.write(Path("output") / metadata_file_name)
+        garbled_zip.write(Path("output") / new_metadata_filename)
 
-    os.remove(Path("output") / metadata_file_name)
+    os.remove(Path("output") / new_metadata_filename)
 
     print("Zip file created at: " + str(Path(args.outputfile)))
 
 
 def main():
     args = parse_arguments()
+    household_time = datetime.datetime.now()
     if not args.householddef:
-        n_households = infer_households(args)
+        n_households = infer_households(args, household_time)
     else:
-        n_households = 0
-    hash_households(args)
-    create_output_zip(args, n_households)
+        with open(args.householddef) as household_file:
+            households = household_file.read()
+        n_households = len(households.split()) - 1
+
+    hash_households(args, household_time)
+    create_output_zip(args, n_households, household_time)
 
 
 if __name__ == "__main__":

--- a/households.py
+++ b/households.py
@@ -157,14 +157,15 @@ def bfs_traverse_matches(pos_to_pairs, position):
 
 
 def get_default_pii_csv(dirname="temp-data"):
-    oldest_ts = datetime.fromtimestamp(0)
-    oldest_name = ""
-    for filename in filter(lambda x: "pii" in x and len(x) == 23, os.listdir(dirname)):
-        timestamp = datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S")
-        if timestamp > oldest_ts:
-            oldest_name = filename
-            oldest_ts = timestamp
-    source_file = Path("temp-data") / oldest_name
+    filenames = list(filter(
+        lambda x: "pii" in x and len(x) == 23, os.listdir(dirname)
+    ))
+    timestamps = [
+        datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S")
+        for filename in filenames
+    ]
+    newest_name = filenames[timestamps.index(max(timestamps))]
+    source_file = Path("temp-data") / newest_name
     return source_file
 
 

--- a/households.py
+++ b/households.py
@@ -157,12 +157,9 @@ def bfs_traverse_matches(pos_to_pairs, position):
 
 
 def get_default_pii_csv(dirname="temp-data"):
-    filenames = list(filter(
-        lambda x: "pii" in x and len(x) == 23, os.listdir(dirname)
-    ))
+    filenames = list(filter(lambda x: "pii" in x and len(x) == 23, os.listdir(dirname)))
     timestamps = [
-        datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S")
-        for filename in filenames
+        datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S") for filename in filenames
     ]
     newest_name = filenames[timestamps.index(max(timestamps))]
     source_file = Path("temp-data") / newest_name

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -155,7 +155,7 @@ def translate_linkids(args):
             source_metadata,
             link_metadata,
             source_name=source_metadata_filename,
-            linkage_name=args.hhlinkszip
+            linkage_name=args.hhlinkszip,
         )
         if len(metadata_issues) == 0:
             write_hh_links(args)

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -3,7 +3,13 @@
 import argparse
 import csv
 import os
+import json
+
+from io import TextIOWrapper
 from pathlib import Path
+from zipfile import ZipFile
+
+from utils.validate_metadata import verify_metadata, get_metadata
 
 HEADERS = ["LINK_ID", "PATID"]
 HH_HEADERS = ["HOUSEHOLD_ID", "PATID"]
@@ -14,15 +20,15 @@ def parse_arguments():
         description="Tool for translating LINK_IDs back into PATIDs"
     )
     parser.add_argument("--sourcefile", help="Source pii-TIMESTAMP.csv file")
-    parser.add_argument("--linksfile", help="LINK_ID CSV file from linkage agent")
+    parser.add_argument("--linkszip", help="LINK_ID CSV file from linkage agent")
     parser.add_argument(
-        "--hhsourcefile",
-        help="Household PII csv, either inferred by households.py"
+        "--hhsourcezip",
+        help="Household PII zip, either inferred by households.py"
         " or provided by data owner",
     )
     parser.add_argument(
-        "--hhlinksfile",
-        help="HOUSEHOLD_ID CSV file from linkage agent",
+        "--hhlinkszip",
+        help="HOUSEHOLD_ID zip file from linkage agent",
     )
     parser.add_argument(
         "-o",
@@ -44,7 +50,7 @@ def parse_source_file(source_file):
 
 
 def write_patid_links(args):
-    links_file = Path(args.linksfile)
+    links_archive = Path(args.linkszip)
     pii_lines = parse_source_file(args.sourcefile)
     with open(
         os.path.join(args.outputdir, "linkid_to_patid.csv"),
@@ -54,15 +60,20 @@ def write_patid_links(args):
     ) as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(HEADERS)
-        with open(links_file) as links:
-            links_reader = csv.reader(links)
-            # Skipping header
-            next(links_reader)
-            for row in links_reader:
-                link_id = row[0]
-                # The +1 accounts for the header row in spreadsheet index
-                patid = pii_lines[int(row[1]) + 1][0]
-                writer.writerow([link_id, patid])
+        with ZipFile(links_archive) as link_zip:
+            links_list = list(filter(lambda x: ".csv" in x, link_zip.namelist()))
+            if len(links_list) > 1:
+                print(f"WARNING: found more than one .csv file in link archive {links_archive.name}")
+                print(f"\tUsing {links_list[0]}")
+            with link_zip.open(links_list[0]) as links:
+                links_reader = csv.reader(TextIOWrapper(links, encoding="UTF-8", newline=""))
+                # Skipping header
+                next(links_reader)
+                for row in links_reader:
+                    link_id = row[0]
+                    # The +1 accounts for the header row in spreadsheet index
+                    patid = pii_lines[int(row[1]) + 1][0]
+                    writer.writerow([link_id, patid])
 
 
 def write_hh_links(args):
@@ -76,30 +87,66 @@ def write_hh_links(args):
     ) as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(HH_HEADERS)
-        with open(hh_links_file) as links:
-            links_reader = csv.reader(links)
-            # Skipping header
-            next(links_reader)
+        with ZipFile(hh_links_file) as hh_archive:
+            hh_links_list = list(filter(lambda x: ".csv" in x, hh_archive.namelist()))
+            if len(hh_links_list) > 1:
+                print(f"WARNING: found more than one .csv file in link archive {links_archive.name}")
+                print(f"\tUsing {hh_links_list[0]}")
+            with hh_archive.open(hh_links_list[0]) as links:
+                links_reader = csv.reader(TextIOWrapper(links, encoding="UTF-8", newline=""))
+                # Skipping header
+                next(links_reader)
 
-            for row in links_reader:
-                household_id = row[0]
-                household_position = row[1]
-                # The +1 accounts for the header row in spreadsheet index
-                # HH_PII headers:
-                # family_name,phone_number,household_street_address,household_zip,record_ids
-                record_ids = hh_pii_lines[int(household_position) + 1][4]
-                record_ids_list = record_ids.split(",")
+                for row in links_reader:
+                    household_id = row[0]
+                    household_position = row[1]
+                    # The +1 accounts for the header row in spreadsheet index
+                    # HH_PII headers:
+                    # family_name,phone_number,household_street_address,household_zip,record_ids
+                    record_ids = hh_pii_lines[int(household_position) + 1][4]
+                    record_ids_list = record_ids.split(",")
 
-                for record_id in record_ids_list:
-                    writer.writerow([household_id, record_id])
+                    for record_id in record_ids_list:
+                        writer.writerow([household_id, record_id])
 
 
 def translate_linkids(args):
-    if args.linksfile and args.sourcefile:
-        write_patid_links(args)
+    if args.linkszip and args.sourcefile:
+        source_metadata_filename = Path(args.sourcefile).parent / Path(
+            args.sourcefile
+        ).name.replace("pii", "metadata").replace(".csv", ".json")
+        with open(source_metadata_filename) as source_metadata_file:
+            source_metadata = json.load(source_metadata_file)
+        link_metadata = get_metadata(args.linkszip)["input_system_metadata"]
+        metadata_issues = verify_metadata(
+            source_metadata,
+            link_metadata,
+            source_name=source_metadata_filename,
+            linkage_name=args.linkszip
+        )
+        if len(metadata_issues) == 0:
+            write_patid_links(args)
+        else:
+            print(f"ERROR: Inconsistencies found in source metadata file {args.sourcefile}"
+                  f" and linkage archive metadata in {args.linkszip}:")
+            for issue in metadata_issues:
+                print('\t'+issue)
 
-    if args.hhlinksfile and args.hhsourcefile:
-        write_hh_links(args)
+    if args.hhlinkszip and args.hhsourcezip:
+        source_metadata_filename = Path(args.sourcefile).parent / Path(
+            args.sourcefile
+        ).name.replace("pii", "metadata").replace(".csv", ".json")
+        with open(source_metadata_filename) as source_metadata_file:
+            source_metadata = json.load(source_metadata_file)
+        link_metadata = get_metadata(args.hhlinkszip)["input_system_metadata"]
+        metadata_issues = verify_metadata(source_metadata, link_metadata)
+        if len(metadata_issues) == 0:
+            write_hh_links(args)
+        else:
+            print(f"ERROR: Inconsistencies found in source metadata file {args.sourcefile}"
+                  f" and linkage archive metadata in {args.linkszip}:")
+            for issue in metadata_issues:
+                print('\t'+issue)
 
 
 def main():

--- a/utils/validate_metadata.py
+++ b/utils/validate_metadata.py
@@ -46,9 +46,7 @@ def get_metadata(archive_path_str):
     return metadata
 
 
-def verify_metadata(args):
-    source_json = get_metadata(args.source_archive)
-    linkage_json = get_metadata(args.linkage_archive)["input_system_metadata"]
+def verify_metadata(source_json, linkage_json, source_name="source_json", linkage_name="linkage_json"):
     metadata_issues = []
     source_keys = set(source_json.keys())
     linkage_keys = set(linkage_json.keys())
@@ -66,15 +64,17 @@ def verify_metadata(args):
         elif source_json[key] != linkage_json[key]:
             metadata_issues.append(
                 f"Disagreement in value for key {key}"
-                f"\n\t {args.source_archive} has value {source_json[key]}"
-                f"\n\t {args.linkage_archive} has value {linkage_json[key]}"
+                f"\n\t {source_name} has value {source_json[key]}"
+                f"\n\t {linkage_name} has value {linkage_json[key]}"
             )
     return metadata_issues
 
 
 def main():
     args = parse_arguments()
-    metadata_issues = verify_metadata(args)
+    source_json = get_metadata(args.source_archive)
+    linkage_json = get_metadata(args.linkage_archive)["input_system_metadata"]
+    metadata_issues = verify_metadata(source_json, linkage_json)
     if len(metadata_issues) > 0:
         print(f"Validation Failed: \nFound {len(metadata_issues)} issues")
         if args.verbose:

--- a/utils/validate_metadata.py
+++ b/utils/validate_metadata.py
@@ -55,13 +55,11 @@ def verify_metadata(
     for key in source_keys.union(linkage_keys):
         if key not in source_keys:
             metadata_issues.append(
-                f"Found key {key} in {linkage_name}, "
-                f"but not in {source_name}"
+                f"Found key {key} in {linkage_name}, " f"but not in {source_name}"
             )
         elif key not in linkage_keys:
             metadata_issues.append(
-                f"Found key {key} in {source_name},"
-                f" but not in {linkage_name}"
+                f"Found key {key} in {source_name}," f" but not in {linkage_name}"
             )
         elif source_json[key] != linkage_json[key]:
             metadata_issues.append(

--- a/utils/validate_metadata.py
+++ b/utils/validate_metadata.py
@@ -46,20 +46,22 @@ def get_metadata(archive_path_str):
     return metadata
 
 
-def verify_metadata(source_json, linkage_json, source_name="source_json", linkage_name="linkage_json"):
+def verify_metadata(
+    source_json, linkage_json, source_name="source_json", linkage_name="linkage_json"
+):
     metadata_issues = []
     source_keys = set(source_json.keys())
     linkage_keys = set(linkage_json.keys())
     for key in source_keys.union(linkage_keys):
         if key not in source_keys:
             metadata_issues.append(
-                f"Found key {key} in {args.linkage_archive}, "
-                f"but not in {args.source_archive}"
+                f"Found key {key} in {linkage_name}, "
+                f"but not in {source_name}"
             )
         elif key not in linkage_keys:
             metadata_issues.append(
-                f"Found key {key} in {args.source_archive},"
-                f" but not in {args.linkage_archive}"
+                f"Found key {key} in {source_name},"
+                f" but not in {linkage_name}"
             )
         elif source_json[key] != linkage_json[key]:
             metadata_issues.append(

--- a/verify-linkage-metadata.py
+++ b/verify-linkage-metadata.py
@@ -1,16 +1,21 @@
 import argparse
 import json
-
 from pathlib import Path
 from zipfile import ZipFile
 
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        description="Tool for verifying metadata sent to and received from linkage agent against one another."
+        description="Tool for verifying metadata sent to and received from"
+        "linkage agent against one another."
     )
-    parser.add_argument("source_archive", help="path to ZIP archive containing garbled PII")
-    parser.add_argument("linkage_archive", help="path ZIP archive containing PPRL results from linkage agent")
+    parser.add_argument(
+        "source_archive", help="path to ZIP archive containing garbled PII"
+    )
+    parser.add_argument(
+        "linkage_archive",
+        help="path ZIP archive containing PPRL results from linkage agent",
+    )
     parser.add_argument(
         "-v",
         "--verbose",
@@ -50,11 +55,13 @@ def verify_metadata(args):
     for key in source_keys.union(linkage_keys):
         if key not in source_keys:
             metadata_issues.append(
-                f"Found key {key} in {args.linkage_archive}, but not in {args.source_archive}"
+                f"Found key {key} in {args.linkage_archive}, "
+                f"but not in {args.source_archive}"
             )
         elif key not in linkage_keys:
             metadata_issues.append(
-                f"Found key {key} in {args.source_archive}, but not in {args.linkage_archive}"
+                f"Found key {key} in {args.source_archive},"
+                f" but not in {args.linkage_archive}"
             )
         elif source_json[key] != linkage_json[key]:
             metadata_issues.append(
@@ -72,10 +79,10 @@ def main():
         print(f"Validation Failed: \nFound {len(metadata_issues)} issues")
         if args.verbose:
             for issue in metadata_issues:
-                print("\t"+issue)
+                print("\t" + issue)
     else:
         print(f"Validation Successful: Found {len(metadata_issues)} issues")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/verify-linkage-metadata.py
+++ b/verify-linkage-metadata.py
@@ -1,0 +1,81 @@
+import argparse
+import json
+
+from pathlib import Path
+from zipfile import ZipFile
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Tool for verifying metadata sent to and received from linkage agent against one another."
+    )
+    parser.add_argument("source_archive", help="path to ZIP archive containing garbled PII")
+    parser.add_argument("linkage_archive", help="path ZIP archive containing PPRL results from linkage agent")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Verbose mode prints output to console",
+    )
+    args = parser.parse_args()
+    if not Path(args.source_archive).exists():
+        parser.error("Unable to find source archive: " + args.source_archive)
+    if not Path(args.linkage_archive).exists():
+        parser.error("Unable to find linkage archive: " + args.linkage_archive)
+    return args
+
+
+def get_metadata(archive_path_str):
+    with ZipFile(archive_path_str) as archive:
+        metadata_namelist = list(filter(lambda x: "metadata" in x, archive.namelist()))
+        if len(metadata_namelist) == 0:
+            print(f"WARNING: could not find metadata file in {archive_path_str}")
+            return
+        if len(metadata_namelist) > 1:
+            print(f"WARNING: found more than one metadata file in {archive_path_str}")
+            print(f"\tUsing {metadata_namelist[0]}")
+        with archive.open(metadata_namelist[0]) as meta_file:
+            metadata = json.load(meta_file)
+
+    return metadata
+
+
+def verify_metadata(args):
+    source_json = get_metadata(args.source_archive)
+    linkage_json = get_metadata(args.linkage_archive)["input_system_metadata"]
+    metadata_issues = []
+    source_keys = set(source_json.keys())
+    linkage_keys = set(linkage_json.keys())
+    for key in source_keys.union(linkage_keys):
+        if key not in source_keys:
+            metadata_issues.append(
+                f"Found key {key} in {args.linkage_archive}, but not in {args.source_archive}"
+            )
+        elif key not in linkage_keys:
+            metadata_issues.append(
+                f"Found key {key} in {args.source_archive}, but not in {args.linkage_archive}"
+            )
+        elif source_json[key] != linkage_json[key]:
+            metadata_issues.append(
+                f"Disagreement in value for key {key}"
+                f"\n\t {args.source_archive} has value {source_json[key]}"
+                f"\n\t {args.linkage_archive} has value {linkage_json[key]}"
+            )
+    return metadata_issues
+
+
+def main():
+    args = parse_arguments()
+    metadata_issues = verify_metadata(args)
+    if len(metadata_issues) > 0:
+        print(f"Validation Failed: \nFound {len(metadata_issues)} issues")
+        if args.verbose:
+            for issue in metadata_issues:
+                print("\t"+issue)
+    else:
+        print(f"Validation Successful: Found {len(metadata_issues)} issues")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
`households.py` and `garble.py` now both look for the newest file (based on filename timestamp) in the `temp-data` directory if no `sourcefile` argument is passed from the command line. For [ticket #183028439](https://www.pivotaltracker.com/story/show/183028439)