### PR TITLE
Update Schema with All Allowable Sex Values

### DIFF
--- a/example-schema/name-sex-dob-addr.json
+++ b/example-schema/name-sex-dob-addr.json
@@ -87,9 +87,12 @@
       "format": {
         "type": "enum",
         "values": [
-          "M",
+          "A",
           "F",
-          "UN"
+          "M",
+          "NI",
+          "UN",
+          "OT"
         ]
       },
       "hashing": {

--- a/example-schema/name-sex-dob-phone.json
+++ b/example-schema/name-sex-dob-phone.json
@@ -87,9 +87,12 @@
       "format": {
         "type": "enum",
         "values": [
-          "M",
+          "A",
           "F",
-          "UN"
+          "M",
+          "NI",
+          "UN",
+          "OT"
         ]
       },
       "hashing": {

--- a/example-schema/name-sex-dob-zip.json
+++ b/example-schema/name-sex-dob-zip.json
@@ -87,9 +87,12 @@
       "format": {
         "type": "enum",
         "values": [
-          "M",
+          "A",
           "F",
-          "UN"
+          "M",
+          "NI",
+          "UN",
+          "OT"
         ]
       },
       "hashing": {


### PR DESCRIPTION
# Summary

The current anonlink schema's only allow `M`, `F`, and `UN` for sex values. The [CODI Data Model (Table 75 of version 4.1.5)](https://raw.githubusercontent.com/mitre/codi/main/CODI%20Data%20Model%20Implementation%20Guide.pdf) indicates `A`, `F`, `M`, `NI`, `UN`, and `OT` are allowed.

This should prevent issues reported by data owners related to invalid codes being present. e.g.:

```shell
Invalid entry in row 617883, column 'sex'. Expected enum value to be one of ['F', 'UN', 'M']. Read 'NI'.
```

[Pivotal Ticket #183238061](https://www.pivotaltracker.com/story/show/183238061)

# Testing Guidance

Run `garble.py` and make sure everything still works.