### PR TITLE
Improve performance of household inference

### DIFF
--- a/households/matching.py
+++ b/households/matching.py
@@ -261,8 +261,9 @@ def get_houshold_matches(pii_lines):
     # note sortedneighborhood on zip probably doesn't make sense
     # (zip codes in a geographic area will be too similar)
     # but if data is dirty then blocks may discard typos
-    indexer.block(['household_zip', 'street'])
-    indexer.block(['household_zip', 'family_name'])
+
+    indexer.block(["household_zip", "street"])
+    indexer.block(["household_zip", "family_name"])
 
     candidate_links = indexer.index(pii_lines)
 

--- a/households/matching.py
+++ b/households/matching.py
@@ -253,13 +253,17 @@ class AddressComparison(BaseCompareFeature):
 
 def get_houshold_matches(pii_lines):
     # indexing step defines the pairs of records for comparison
-    # indexer.all() does a full n^2 comparison, but we can do better
+    # indexer.full() does a full n^2 comparison, but we can do better
     indexer = recordlinkage.Index()
-    # use a block index on zip and street name to reduce the number of candidates.
-    # sortedneighborhood on zip probably doesn't make sense
+    # use two block indexes to reduce the number of candidates
+    # while still retaining enough candidates to identify real households.
+    # a block only on zip could work, but seems to run into memory issues
+    # note sortedneighborhood on zip probably doesn't make sense
     # (zip codes in a geographic area will be too similar)
     # but if data is dirty then blocks may discard typos
     indexer.block(['household_zip', 'street'])
+    indexer.block(['household_zip', 'family_name'])
+
     candidate_links = indexer.index(pii_lines)
 
     # Comparison step performs the defined comparison algorithms

--- a/households/matching.py
+++ b/households/matching.py
@@ -255,13 +255,11 @@ def get_houshold_matches(pii_lines):
     # indexing step defines the pairs of records for comparison
     # indexer.all() does a full n^2 comparison, but we can do better
     indexer = recordlinkage.Index()
-    # use sorted naighborhood here to allow for typos and close matches:
-    # "This algorithm returns record pairs that agree on the sorting key,
-    #  but also records pairs in their neighbourhood."
-    # potentially match on close zips and street names
-    # note that the default "window" aka distance to consider pairs is 3
-    indexer.sortedneighbourhood("household_zip")
-    indexer.sortedneighbourhood("street")
+    # use a block index on zip and street name to reduce the number of candidates.
+    # sortedneighborhood on zip probably doesn't make sense
+    # (zip codes in a geographic area will be too similar)
+    # but if data is dirty then blocks may discard typos
+    indexer.block(['household_zip', 'street'])
     candidate_links = indexer.index(pii_lines)
 
     # Comparison step performs the defined comparison algorithms


### PR DESCRIPTION
The household inference process in households.py is very slow and memory intensive, and for large datasets it's likely to crash with a MemoryError (or get killed by the OS). The problem is that the current indexing approach doesn't discard enough candidates and the system tries to load close to  n^2 pairs into memory. 

As of now the indexing approach uses a sortedneighborhood (with default window=3) on zip code and a sortedneighborhood on street address. The zip index doesn't make sense when working with a single geographic region, because all the zip codes will start with the same few digits. (For example we saw in Denver there are dozens of 801xx codes). The tentative approach which gets the code to run on my system with a set of 3 million rows is to use two block indexes, one on zip and street name and one on zip and family name - this will result in only candidate pairs that match exactly on either pair of these 2 fields.

Some notes on performance and quality:
 - It's still not fast on 3 million records, and it will still be memory constrained at some point if the dataset gets large enough. This is a quick fix intended to get this working, we can revisit and rearchitect if needed.
 - The "ground truth" I'm working with seems to have some quirks. I haven't dug too deeply into this so for now I'm less worried about the absolute scores and more interested in the relative difference between scores and times for each approach.
 - I used the Adjusted Rand Index from sklearn to evaluate this: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.adjusted_rand_score.html

Approach | Score | Candidate links on synthetic NC site A | Runtime on 3M dataset | Candidate links on 3M
-- | -- | -- | -- | --
indexer.full() | 0.72257 | 334971 | n/a (crashed) |  
indexer.sortedneighborhood (current on   master) | 0.72257 | 16239 | n/a (crashed) |  
indexer.block([zip,addr]) (initial PR) | 0.56015 | 279 | 4s index, 21m processing | 5012942
indexer.block(zip only) | 0.71013 | 6273 | n/a (crashed) |  
indexer.block(['household_zip',   'street'])     indexer.block(['household_zip', 'family_name']) (PR as currently submitted) | 0.69025 | 428 | 1m index, 48m processing | 12480397

