### PR TITLE
Timestamp Standardization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ To map the LINK_IDs back to PATIDs, use the `linkid_to_patid.py` script. The scr
 
 1. The path to the pii-timestamp.csv file. 
 2. The path to the LINK_ID CSV file provided by the linkage agent
-3. The path to the household pii CSV file, either provided by the data owner directly or inferred by the `households.py` script (which by default is named `household_pii-timestamp.csv`)
+3. The path to the household pii CSV file, either provided by the data owner directly or inferred by the `households.py` script (which by default is named `household_pii-TIMESTAMP.csv`)
 4. The path to the HOUSEHOLDID CSV file provided by the linkage agent if you provided household information
 
 If both the pii-timestamp.csv and LINK_ID CSV file are provided as arguments, the script will create a file called `linkid_to_patid.csv` with the mapping of LINK_IDs to PATIDs in the `output/` folder by default. If both the household pii-timestamp.csv and LINK_ID CSV file are provided as arguments this will also create a `householdid_to_patid.csv` file in the `output/` folder.

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The metadata created by the garbling process is used to validate the metadata re
 ```
 python utils\validate_metadata.py <path-to-garbled.zip> <path-to-result.zip>
 ```
-So, assuming that the output of `garble.py` is a file, `garble.zip` located in the `output` directory, and assuming that the results from the linkage agent are received as a zip archive named `results.zip` located in the `inbox` directory, the syntax would be
+So, assuming that the output of `garble.py` is a file, `garble.zip` located in the `output` directory, and that the results from the linkage agent are received as a zip archive named `results.zip` located in the `inbox` directory, the syntax would be
 ```
 python utils\validate_metadata.py output\garble.py inbox\results.zip
 ```

--- a/README.md
+++ b/README.md
@@ -282,14 +282,28 @@ To map the LINK_IDs back to PATIDs, use the `linkid_to_patid.py` script. The scr
 
 1. The path to the pii-timestamp.csv file. 
 2. The path to the LINK_ID CSV file provided by the linkage agent
-3. The path to the Household pii-timestamp.csv file, either provided by the data owner directly or inferred by the `households.py` script
+3. The path to the household pii CSV file, either provided by the data owner directly or inferred by the `households.py` script (which by default is named `household_pii-timestamp.csv`)
 4. The path to the HOUSEHOLDID CSV file provided by the linkage agent if you provided household information
 
 If both the pii-timestamp.csv and LINK_ID CSV file are provided as arguments, the script will create a file called `linkid_to_patid.csv` with the mapping of LINK_IDs to PATIDs in the `output/` folder by default. If both the household pii-timestamp.csv and LINK_ID CSV file are provided as arguments this will also create a `householdid_to_patid.csv` file in the `output/` folder.
 
+### [Optional] Independently Validate Result Metadata
+
+The metadata created by the garbling process is used to validate the metadata returned by the linkage agent within the `linkid_to_patid.py` script. Additionally, the metadata returned by the linkage agents can be validated outside of the `linkid_to_patid.py` script using the `validate_metadata.py` script in the `utils` directory. The syntax from the root directory is 
+```
+python utils\validate_metadata.py <path-to-garbled.zip> <path-to-result.zip>
+```
+So, assuming that the output of `garble.py` is a file, `garble.zip` located in the `output` directory, and assuming that the results from the linkage agent are received as a zip archive named `results.zip` located in the `inbox` directory, the syntax would be
+```
+python utils\validate_metadata.py output\garble.py inbox\results.zip
+```
+By default, the script will only return the number of issues found during the validation process. Use the `-v` flag in order to print detailled information about each of the issues encountered during validation.
+
 ## Cleanup
 
 In between runs it is advisable to run `rm temp-data/*` to clean up temporary data files used for individuals runs.
+
+
 
 ## Developer Testing
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Zip file created at: output/garbled.zip
 ```
 ### [Optional] Household Extract and Garble
 
-You may now run `households.py` with the same arguments as the `garble.py` script, with the only difference being specifying a specific schema file instead of a schema directory - if no schema is specified it will default to the `example-schema/household-schema/fn-phone-addr-zip.json`. To specify a schemafile, it must be preceeded by the flag `--schemafile` (use `-h` flag for more information). NOTE: If you want to generate the testing and tuning files for development on a synthetic dataset, you need to specify the `-t` or `--testrun` flags
+You may now run `households.py`. The arguments are similar to `garble.py` script, with the only difference being that specifying a specific schema file must be done using the keyword `--schemafile` instead of positionally. If the `--schemafile` is not used to specify a specefic schema, it will default to the `example-schema/household-schema/fn-phone-addr-zip.json` (use `-h` flag for more information). NOTE: If you want to generate the testing and tuning files for development on a synthetic dataset, you need to specify the `-t` or `--testrun` flags
 
 The households script will do the following:
   1. Attempt to group individuals into households and store those records in a csv file in temp-data

--- a/definitions.py
+++ b/definitions.py
@@ -1,1 +1,4 @@
+import datetime
+
 TIMESTAMP_FMT = "%Y%m%dT%H%M%S"
+TIMESTAMP_LEN = len(datetime.datetime.now().strftime(TIMESTAMP_FMT))

--- a/definitions.py
+++ b/definitions.py
@@ -1,0 +1,1 @@
+TIMESTAMP_FMT = "%Y%m%dT%H%M%S"

--- a/example-schema/name-sex-dob-addr.json
+++ b/example-schema/name-sex-dob-addr.json
@@ -87,9 +87,12 @@
       "format": {
         "type": "enum",
         "values": [
-          "M",
+          "A",
           "F",
-          "UN"
+          "M",
+          "NI",
+          "UN",
+          "OT"
         ]
       },
       "hashing": {

--- a/example-schema/name-sex-dob-phone.json
+++ b/example-schema/name-sex-dob-phone.json
@@ -87,9 +87,12 @@
       "format": {
         "type": "enum",
         "values": [
-          "M",
+          "A",
           "F",
-          "UN"
+          "M",
+          "NI",
+          "UN",
+          "OT"
         ]
       },
       "hashing": {

--- a/example-schema/name-sex-dob-zip.json
+++ b/example-schema/name-sex-dob-zip.json
@@ -87,9 +87,12 @@
       "format": {
         "type": "enum",
         "values": [
-          "M",
+          "A",
           "F",
-          "UN"
+          "M",
+          "NI",
+          "UN",
+          "OT"
         ]
       },
       "hashing": {

--- a/extract.py
+++ b/extract.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from random import shuffle
 from time import strftime, strptime
 
+from definitions import TIMESTAMP_FMT
 from sqlalchemy import create_engine
 
-from utils.constants import timestamp_fmt_str
 from utils.data_reader import (
     add_parser_db_args,
     case_insensitive_lookup,
@@ -36,8 +36,6 @@ HEADER = [
 
 V1 = "v1"
 V2 = "v2"
-
-TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():

--- a/extract.py
+++ b/extract.py
@@ -14,6 +14,7 @@ from time import strftime, strptime
 
 from sqlalchemy import create_engine
 
+from utils.constants import timestamp_fmt_str
 from utils.data_reader import (
     add_parser_db_args,
     case_insensitive_lookup,
@@ -35,6 +36,8 @@ HEADER = [
 
 V1 = "v1"
 V2 = "v2"
+
+TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():
@@ -260,7 +263,7 @@ def write_metadata(n_rows, creation_time):
         "creation_date": creation_time.isoformat(),
         "uuid1": str(uuid.uuid1()),
     }
-    timestamp = datetime.strftime(creation_time, "%Y%m%dT%H%M%S")
+    timestamp = datetime.strftime(creation_time, TIMESTAMP_FMT)
     metaname = Path("temp-data") / f"metadata-{timestamp}.json"
     with open(metaname, "w", newline="", encoding="utf-8") as metafile:
         json.dump(metadata, metafile, indent=2)
@@ -268,7 +271,7 @@ def write_metadata(n_rows, creation_time):
 
 def write_data(output_rows, args):
     creation_time = datetime.now()
-    timestamp = datetime.strftime(creation_time, "%Y%m%dT%H%M%S")
+    timestamp = datetime.strftime(creation_time, TIMESTAMP_FMT)
     os.makedirs("temp-data", exist_ok=True)
     csvname = f"temp-data/pii-{timestamp}.csv"
     with open(csvname, "w", newline="", encoding="utf-8") as csvfile:

--- a/extract.py
+++ b/extract.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from random import shuffle
 from time import strftime, strptime
 
-from definitions import TIMESTAMP_FMT
 from sqlalchemy import create_engine
 
+from definitions import TIMESTAMP_FMT
 from utils.data_reader import (
     add_parser_db_args,
     case_insensitive_lookup,

--- a/garble.py
+++ b/garble.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from zipfile import ZipFile
 
-from definitions import TIMESTAMP_FMT
+from definitions import TIMESTAMP_FMT, TIMESTAMP_LEN
 from derive_subkey import derive_subkey
 
 
@@ -79,7 +79,7 @@ def garble_pii(args):
         source_file = Path(args.sourcefile)
     else:
         filenames = list(
-            filter(lambda x: "pii" in x and len(x) == 23, os.listdir("temp-data"))
+            filter(lambda x: "pii" in x and len(x) == 8 + TIMESTAMP_LEN, os.listdir("temp-data"))
         )
         timestamps = [
             datetime.strptime(filename[4:-4], TIMESTAMP_FMT) for filename in filenames

--- a/garble.py
+++ b/garble.py
@@ -9,9 +9,12 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+from utils import constants
 from zipfile import ZipFile
 
 from derive_subkey import derive_subkey
+
+TIMESTAMP_FMT = constants.timestamp_fmt_str
 
 
 def parse_arguments():
@@ -81,7 +84,7 @@ def garble_pii(args):
             filter(lambda x: "pii" in x and len(x) == 23, os.listdir("temp-data"))
         )
         timestamps = [
-            datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S") for filename in filenames
+            datetime.strptime(filename[4:-4], TIMESTAMP_FMT) for filename in filenames
         ]
         newest_name = filenames[timestamps.index(max(timestamps))]
         source_file = Path("temp-data") / newest_name

--- a/garble.py
+++ b/garble.py
@@ -79,7 +79,10 @@ def garble_pii(args):
         source_file = Path(args.sourcefile)
     else:
         filenames = list(
-            filter(lambda x: "pii" in x and len(x) == 8 + TIMESTAMP_LEN, os.listdir("temp-data"))
+            filter(
+                lambda x: "pii" in x and len(x) == 8 + TIMESTAMP_LEN,
+                os.listdir("temp-data"),
+            )
         )
         timestamps = [
             datetime.strptime(filename[4:-4], TIMESTAMP_FMT) for filename in filenames

--- a/garble.py
+++ b/garble.py
@@ -9,12 +9,11 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from utils import constants
 from zipfile import ZipFile
 
+from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 
-TIMESTAMP_FMT = constants.timestamp_fmt_str
 
 
 def parse_arguments():

--- a/garble.py
+++ b/garble.py
@@ -15,7 +15,6 @@ from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 
 
-
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Tool for garbling PII in for PPRL purposes in the CODI project"

--- a/households.py
+++ b/households.py
@@ -15,6 +15,7 @@ import pandas as pd
 
 from derive_subkey import derive_subkey
 from households.matching import addr_parse, get_houshold_matches
+from utils.constants import timestamp_fmt_str
 
 HEADERS = ["HOUSEHOLD_POSITION", "PII_POSITIONS"]
 HOUSEHOLD_PII_HEADERS = [
@@ -25,6 +26,8 @@ HOUSEHOLD_PII_HEADERS = [
     "record_ids",
 ]
 HOUSEHOLD_POS_PID_HEADERS = ["household_position", "pid"]
+
+TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():
@@ -121,7 +124,7 @@ def parse_source_file(source_file):
 
 def write_households_pii(output_rows, household_time):
     shuffle(output_rows)
-    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
+    timestamp = household_time.strftime(TIMESTAMP_FMT)
     with open(
         Path("temp-data") / f"households_pii-{timestamp}.csv",
         "w",
@@ -159,7 +162,7 @@ def bfs_traverse_matches(pos_to_pairs, position):
 def get_default_pii_csv(dirname="temp-data"):
     filenames = list(filter(lambda x: "pii" in x and len(x) == 23, os.listdir(dirname)))
     timestamps = [
-        datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S") for filename in filenames
+        datetime.strptime(filename[4:-4], TIMESTAMP_FMT) for filename in filenames
     ]
     newest_name = filenames[timestamps.index(max(timestamps))]
     source_file = Path("temp-data") / newest_name
@@ -240,7 +243,7 @@ def write_hid_hh_pos_map(pos_pid_rows):
 
 
 def hash_households(args, household_time):
-    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
+    timestamp = household_time.strftime(TIMESTAMP_FMT)
     schema_file = Path(args.schemafile)
     secret_file = Path(args.secretfile)
     secret = validate_secret_file(secret_file)
@@ -283,7 +286,7 @@ def infer_households(args, household_time):
 
 def create_output_zip(args, n_households, household_time):
 
-    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
+    timestamp = household_time.strftime(TIMESTAMP_FMT)
 
     if args.sourcefile:
         source_file = Path(args.sourcefile)

--- a/households.py
+++ b/households.py
@@ -13,9 +13,9 @@ from zipfile import ZipFile
 
 import pandas as pd
 
+from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 from households.matching import addr_parse, get_houshold_matches
-from utils.constants import timestamp_fmt_str
 
 HEADERS = ["HOUSEHOLD_POSITION", "PII_POSITIONS"]
 HOUSEHOLD_PII_HEADERS = [
@@ -26,8 +26,6 @@ HOUSEHOLD_PII_HEADERS = [
     "record_ids",
 ]
 HOUSEHOLD_POS_PID_HEADERS = ["household_position", "pid"]
-
-TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -2,8 +2,14 @@
 
 import argparse
 import csv
+import json
 import os
+import sys
+from io import TextIOWrapper
 from pathlib import Path
+from zipfile import ZipFile
+
+from utils.validate_metadata import get_metadata, verify_metadata
 
 HEADERS = ["LINK_ID", "PATID"]
 HH_HEADERS = ["HOUSEHOLD_ID", "PATID"]
@@ -14,15 +20,15 @@ def parse_arguments():
         description="Tool for translating LINK_IDs back into PATIDs"
     )
     parser.add_argument("--sourcefile", help="Source pii-TIMESTAMP.csv file")
-    parser.add_argument("--linksfile", help="LINK_ID CSV file from linkage agent")
+    parser.add_argument("--linkszip", help="LINK_ID CSV file from linkage agent")
     parser.add_argument(
         "--hhsourcefile",
         help="Household PII csv, either inferred by households.py"
         " or provided by data owner",
     )
     parser.add_argument(
-        "--hhlinksfile",
-        help="HOUSEHOLD_ID CSV file from linkage agent",
+        "--hhlinkszip",
+        help="HOUSEHOLD_ID zip file from linkage agent",
     )
     parser.add_argument(
         "-o",
@@ -44,7 +50,7 @@ def parse_source_file(source_file):
 
 
 def write_patid_links(args):
-    links_file = Path(args.linksfile)
+    links_archive = Path(args.linkszip)
     pii_lines = parse_source_file(args.sourcefile)
     with open(
         os.path.join(args.outputdir, "linkid_to_patid.csv"),
@@ -54,19 +60,28 @@ def write_patid_links(args):
     ) as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(HEADERS)
-        with open(links_file) as links:
-            links_reader = csv.reader(links)
-            # Skipping header
-            next(links_reader)
-            for row in links_reader:
-                link_id = row[0]
-                # The +1 accounts for the header row in spreadsheet index
-                patid = pii_lines[int(row[1]) + 1][0]
-                writer.writerow([link_id, patid])
+        with ZipFile(links_archive) as link_zip:
+            links_list = list(filter(lambda x: ".csv" in x, link_zip.namelist()))
+            if len(links_list) > 1:
+                sys.exit(
+                    f"ERROR: found more than one .csv "
+                    f"file in link archive {links_archive.name}"
+                )
+            with link_zip.open(links_list[0]) as links:
+                links_reader = csv.reader(
+                    TextIOWrapper(links, encoding="UTF-8", newline="")
+                )
+                # Skipping header
+                next(links_reader)
+                for row in links_reader:
+                    link_id = row[0]
+                    # The +1 accounts for the header row in spreadsheet index
+                    patid = pii_lines[int(row[1]) + 1][0]
+                    writer.writerow([link_id, patid])
 
 
 def write_hh_links(args):
-    hh_links_file = Path(args.hhlinksfile)
+    hh_links_file = Path(args.hhlinkszip)
     hh_pii_lines = parse_source_file(args.hhsourcefile)
     with open(
         os.path.join(args.outputdir, "householdid_to_patid.csv"),
@@ -76,30 +91,82 @@ def write_hh_links(args):
     ) as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(HH_HEADERS)
-        with open(hh_links_file) as links:
-            links_reader = csv.reader(links)
-            # Skipping header
-            next(links_reader)
+        with ZipFile(hh_links_file) as hh_archive:
+            hh_links_list = list(filter(lambda x: ".csv" in x, hh_archive.namelist()))
+            if len(hh_links_list) > 1:
+                print(
+                    f"WARNING: found more than one .csv "
+                    f"file in link archive {hh_links_file.name}"
+                )
+                print(f"\tUsing {hh_links_list[0]}")
+            with hh_archive.open(hh_links_list[0]) as links:
+                links_reader = csv.reader(
+                    TextIOWrapper(links, encoding="UTF-8", newline="")
+                )
+                # Skipping header
+                next(links_reader)
 
-            for row in links_reader:
-                household_id = row[0]
-                household_position = row[1]
-                # The +1 accounts for the header row in spreadsheet index
-                # HH_PII headers:
-                # family_name,phone_number,household_street_address,household_zip,record_ids
-                record_ids = hh_pii_lines[int(household_position) + 1][4]
-                record_ids_list = record_ids.split(",")
+                for row in links_reader:
+                    household_id = row[0]
+                    household_position = row[1]
+                    # The +1 accounts for the header row in spreadsheet index
+                    # HH_PII headers:
+                    # family_name,phone_number,household_street_address,household_zip,record_ids
+                    record_ids = hh_pii_lines[int(household_position) + 1][4]
+                    record_ids_list = record_ids.split(",")
 
-                for record_id in record_ids_list:
-                    writer.writerow([household_id, record_id])
+                    for record_id in record_ids_list:
+                        writer.writerow([household_id, record_id])
 
 
 def translate_linkids(args):
-    if args.linksfile and args.sourcefile:
-        write_patid_links(args)
+    if args.linkszip and args.sourcefile:
+        source_metadata_filename = Path(args.sourcefile).parent / Path(
+            args.sourcefile
+        ).name.replace("pii", "metadata").replace(".csv", ".json")
+        with open(source_metadata_filename) as source_metadata_file:
+            source_metadata = json.load(source_metadata_file)
+        link_metadata = get_metadata(args.linkszip)["input_system_metadata"]
+        metadata_issues = verify_metadata(
+            source_metadata,
+            link_metadata,
+            source_name=source_metadata_filename,
+            linkage_name=args.linkszip,
+        )
+        if len(metadata_issues) == 0:
+            write_patid_links(args)
+        else:
+            print(
+                f"ERROR: Inconsistencies found in "
+                f"source metadata file {args.sourcefile}"
+                f" and linkage archive metadata in {args.linkszip}:"
+            )
+            for issue in metadata_issues:
+                print("\t" + issue)
 
-    if args.hhlinksfile and args.hhsourcefile:
-        write_hh_links(args)
+    if args.hhlinkszip and args.hhsourcefile:
+        source_metadata_filename = Path(args.hhsourcefile).parent / Path(
+            args.hhsourcefile
+        ).name.replace("pii", "metadata").replace(".csv", ".json")
+        with open(source_metadata_filename) as source_metadata_file:
+            source_metadata = json.load(source_metadata_file)
+        link_metadata = get_metadata(args.hhlinkszip)["input_system_metadata"]
+        metadata_issues = verify_metadata(
+            source_metadata,
+            link_metadata,
+            source_name=source_metadata_filename,
+            linkage_name=args.hhlinkszip,
+        )
+        if len(metadata_issues) == 0:
+            write_hh_links(args)
+        else:
+            print(
+                f"ERROR: Inconsistencies found in source "
+                f"metadata file {args.sourcefile}"
+                f" and linkage archive metadata in {args.linkszip}:"
+            )
+            for issue in metadata_issues:
+                print("\t" + issue)
 
 
 def main():

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -20,7 +20,7 @@ def parse_arguments():
         description="Tool for translating LINK_IDs back into PATIDs"
     )
     parser.add_argument("--sourcefile", help="Source pii-TIMESTAMP.csv file")
-    parser.add_argument("--linkszip", help="LINK_ID CSV file from linkage agent")
+    parser.add_argument("--linkszip", help="LINK_ID ZIP file from linkage agent")
     parser.add_argument(
         "--hhsourcefile",
         help="Household PII csv, either inferred by households.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 flake8==4.0.1
 isort==5.10.1
-SQLAlchemy>=1.4.35
+SQLAlchemy~=1.4.35
 clkhash>=0.16.0
 psycopg2>=2.8.3
 anonlink-client>=0.1.4

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,1 +1,0 @@
-timestamp_fmt_str = "%Y%m%dT%H%M%S"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,1 @@
+timestamp_fmt_str = "%Y%m%dT%H%M%S"

--- a/utils/validate_metadata.py
+++ b/utils/validate_metadata.py
@@ -1,0 +1,88 @@
+import argparse
+import json
+from pathlib import Path
+from zipfile import ZipFile
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Tool for verifying metadata sent to and received from"
+        "linkage agent against one another."
+    )
+    parser.add_argument(
+        "source_archive", help="path to ZIP archive containing garbled PII"
+    )
+    parser.add_argument(
+        "linkage_archive",
+        help="path ZIP archive containing PPRL results from linkage agent",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Verbose mode prints output to console",
+    )
+    args = parser.parse_args()
+    if not Path(args.source_archive).exists():
+        parser.error("Unable to find source archive: " + args.source_archive)
+    if not Path(args.linkage_archive).exists():
+        parser.error("Unable to find linkage archive: " + args.linkage_archive)
+    return args
+
+
+def get_metadata(archive_path_str):
+    with ZipFile(archive_path_str) as archive:
+        metadata_namelist = list(filter(lambda x: "metadata" in x, archive.namelist()))
+        if len(metadata_namelist) == 0:
+            print(f"WARNING: could not find metadata file in {archive_path_str}")
+            return
+        if len(metadata_namelist) > 1:
+            print(f"WARNING: found more than one metadata file in {archive_path_str}")
+            print(f"\tUsing {metadata_namelist[0]}")
+        with archive.open(metadata_namelist[0]) as meta_file:
+            metadata = json.load(meta_file)
+
+    return metadata
+
+
+def verify_metadata(
+    source_json, linkage_json, source_name="source_json", linkage_name="linkage_json"
+):
+    metadata_issues = []
+    source_keys = set(source_json.keys())
+    linkage_keys = set(linkage_json.keys())
+    for key in source_keys.union(linkage_keys):
+        if key not in source_keys:
+            metadata_issues.append(
+                f"Found key {key} in {linkage_name}, " f"but not in {source_name}"
+            )
+        elif key not in linkage_keys:
+            metadata_issues.append(
+                f"Found key {key} in {source_name}," f" but not in {linkage_name}"
+            )
+        elif source_json[key] != linkage_json[key]:
+            metadata_issues.append(
+                f"Disagreement in value for key {key}"
+                f"\n\t {source_name} has value {source_json[key]}"
+                f"\n\t {linkage_name} has value {linkage_json[key]}"
+            )
+    return metadata_issues
+
+
+def main():
+    args = parse_arguments()
+    source_json = get_metadata(args.source_archive)
+    linkage_json = get_metadata(args.linkage_archive)["input_system_metadata"]
+    metadata_issues = verify_metadata(source_json, linkage_json)
+    if len(metadata_issues) > 0:
+        print(f"Validation Failed: \nFound {len(metadata_issues)} issues")
+        if args.verbose:
+            for issue in metadata_issues:
+                print("\t" + issue)
+    else:
+        print(f"Validation Successful: Found {len(metadata_issues)} issues")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Standardized the timestamp format used in canonical file naming by adding a `definitions.py` file that defines it. This doesn't change much, but if we choose to change the time stamp convention doing so will be much simpler.

see sister PR [linkage-agent-tools#31](https://github.com/mitre/linkage-agent-tools/pull/31)

In completion of [ticket #183428340](https://www.pivotaltracker.com/story/show/183428340)