### PR TITLE
Concat address

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -201,8 +201,10 @@ def translate_row(row, report, conf):
     output_row.append(
         value_maps.get("phone", {}).get(clean_phone_number, clean_phone_number)
     )
-
-    household_street_address = translation_lookup(row, "address", column_maps)
+    # address_street and address_detail are both possible in csv
+    # fix below depends on addition of default value for address_detail to sample_conf.json 
+    # to convert empty address_detail to empty string instead of returning None
+    household_street_address = translation_lookup(row, "address_street", column_maps) + " " + translation_lookup(row, "address_detail", column_maps)
     validate(report, "household_street_address", household_street_address, value_maps)
     clean_household_street_address = clean_string(household_street_address)
     output_row.append(

--- a/extract.py
+++ b/extract.py
@@ -29,7 +29,8 @@ HEADER = [
     "DOB",
     "sex",
     "phone_number",
-    "household_street_address",
+    "address street",
+    "address detail",
     "household_zip",
 ]
 
@@ -96,7 +97,6 @@ def clean_phone(phone):
     if phone is None:
         return None
     return "".join(filter(lambda x: x.isdigit(), phone.strip()))
-
 
 def clean_zip(household_zip):
     if household_zip is None:
@@ -203,11 +203,18 @@ def translate_row(row, report, conf):
     )
     # address_street and address_detail are both possible in csv
     # fix below depends on addition of default value for address_detail to sample_conf.json 
-    # to convert empty address_detail to empty string instead of returning None
-    household_street_address = translation_lookup(row, "address_street", column_maps) + " " + translation_lookup(row, "address_detail", column_maps)
-    validate(report, "household_street_address", household_street_address, value_maps)
-    clean_household_street_address = clean_string(household_street_address)
+    # to convert potential empty address_detail to empty string instead of returning None
+    household_street_address1 = translation_lookup(row, "address street", column_maps)
+    household_street_address2 = translation_lookup(row, "address detail", column_maps)
+    validate(report, "address street", household_street_address1, value_maps)
+    validate(report, "address detail", household_street_address2 , value_maps)
+    household_street_address1 = value_maps.get("address street", {}).get(
+        household_street_address1, household_street_address1)
+    household_street_address2 = value_maps.get("address detail", {}).get(
+        household_street_address2, household_street_address2)
+    clean_household_street_address = clean_string(household_street_address1.strip() + " " + household_street_address2.strip())
     output_row.append(
+        # keep call to mapping below in case there are replacements desired for entire address
         value_maps.get("address", {}).get(
             clean_household_street_address, clean_household_street_address
         )

--- a/extract.py
+++ b/extract.py
@@ -98,6 +98,7 @@ def clean_phone(phone):
         return None
     return "".join(filter(lambda x: x.isdigit(), phone.strip()))
 
+
 def clean_zip(household_zip):
     if household_zip is None:
         return None
@@ -202,19 +203,25 @@ def translate_row(row, report, conf):
         value_maps.get("phone", {}).get(clean_phone_number, clean_phone_number)
     )
     # address_street and address_detail are both possible in csv
-    # fix below depends on addition of default value for address_detail to sample_conf.json 
-    # to convert potential empty address_detail to empty string instead of returning None
+    # fix below depends on addition of default value for address_detail to
+    # sample_conf.json to convert potential empty address_detail to empty string
+    # instead of returning None
     household_street_address1 = translation_lookup(row, "address street", column_maps)
     household_street_address2 = translation_lookup(row, "address detail", column_maps)
     validate(report, "address street", household_street_address1, value_maps)
-    validate(report, "address detail", household_street_address2 , value_maps)
+    validate(report, "address detail", household_street_address2, value_maps)
     household_street_address1 = value_maps.get("address street", {}).get(
-        household_street_address1, household_street_address1)
+        household_street_address1, household_street_address1
+    )
     household_street_address2 = value_maps.get("address detail", {}).get(
-        household_street_address2, household_street_address2)
-    clean_household_street_address = clean_string(household_street_address1.strip() + " " + household_street_address2.strip())
+        household_street_address2, household_street_address2
+    )
+    clean_household_street_address = clean_string(
+        household_street_address1.strip() + " " + household_street_address2.strip()
+    )
     output_row.append(
-        # keep call to mapping below in case there are replacements desired for entire address
+        # keep call to mapping below in case there are replacements
+        # desired for entire address
         value_maps.get("address", {}).get(
             clean_household_street_address, clean_household_street_address
         )

--- a/testing-and-tuning/sample_conf.json
+++ b/testing-and-tuning/sample_conf.json
@@ -10,7 +10,8 @@
     "zip": "Zip",
     "default_values": {
       "sex": "F",
-      "address_detail": "",
+      "address_street": "",
+      "address_detail": ""
     }
   },
   "value_mapping_rules": {

--- a/testing-and-tuning/sample_conf.json
+++ b/testing-and-tuning/sample_conf.json
@@ -9,7 +9,8 @@
     "address": "Street Address 1",
     "zip": "Zip",
     "default_values": {
-      "sex": "F"
+      "sex": "F",
+      "address_detail": "",
     }
   },
   "value_mapping_rules": {

--- a/testing-and-tuning/sample_conf.json
+++ b/testing-and-tuning/sample_conf.json
@@ -10,12 +10,13 @@
     "zip": "Zip",
     "default_values": {
       "sex": "F",
-      "address_street": "",
-      "address_detail": ""
+      "address detail": ""
     }
   },
   "value_mapping_rules": {
     "sex": {"Female": "F", "Male": "M"},
-    "phone": {"1234567890": "PLACEHOLDER/UNKNOWN"}
+    "phone": {"1234567890": "PLACEHOLDER/UNKNOWN"},
+    "address street": {"N/A" : ""},
+    "address detail": {"N/A" : ""}
   }
 }


### PR DESCRIPTION
Re-pushed after running black and flake8.
Could be done more elegantly by allowing mapping in translation map to be a list, which can be done in the future. This PR addresses the need to handle the 2 specific address columns mentioned in https://www.pivotaltracker.com/story/show/182872990 and adds some data cleanup for the two address fields.