### PR TITLE
Lock `sqlalchemy` dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 flake8==4.0.1
 isort==5.10.1
-SQLAlchemy>=1.4.35
+SQLAlchemy~=1.4.35
 clkhash>=0.16.0
 psycopg2>=2.8.3
 anonlink-client>=0.1.4


### PR DESCRIPTION
Locks the SQLAlchemy dependency.

2.0.0b1 was released today.