### PR TITLE
data_reader.py now only queries distinct patids from the private_address_history table

### DIFF
--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -148,7 +148,7 @@ def get_query(engine, version, args):
         # with no further filtering
         query = select([prv_demo, prv_address]).filter(
             prv_demo.columns.patid == prv_address.columns.patid
-        )
+        ).distinct(prv_address.columns.patid)
 
         return query
 

--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -147,12 +147,14 @@ def get_query(engine, version, args):
             select(prv_address.columns.addressid)
             .filter(prv_address.columns.patid == prv_demo.columns.patid)
             .order_by(prv_address.columns.address_preferred.desc())
-            .order_by(prv_address.columns.address_period_start.desc())
+            .order_by(prv_address.columns.address_period_start.desc().nulls_last())
             .limit(1)
             .correlate(prv_demo)
+            .scalar_subquery()
         )
 
         query = select([prv_demo, prv_address]).filter(
+            prv_demo.columns.patid == prv_address.columns.patid,
             prv_address.columns.addressid == subquery
         )
 

--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -143,12 +143,11 @@ def get_query(engine, version, args):
             schema=args.v2_schema,
         )
 
-        # the expectation is there will only be one record per individual
-        # in private_address_history, so we simply join the tables
-        # with no further filtering
-        query = select([prv_demo, prv_address]).filter(
-            prv_demo.columns.patid == prv_address.columns.patid
-        ).distinct(prv_address.columns.patid)
+        query = (
+            select([prv_demo, prv_address])
+            .filter(prv_demo.columns.patid == prv_address.columns.patid)
+            .distinct(prv_address.columns.patid)
+        )
 
         return query
 

--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -143,11 +143,19 @@ def get_query(engine, version, args):
             schema=args.v2_schema,
         )
 
-        query = (
-            select([prv_demo, prv_address])
-            .filter(prv_demo.columns.patid == prv_address.columns.patid)
-            .distinct(prv_address.columns.patid)
+        subquery = (
+            select(prv_address.columns.addressid)
+            .filter(prv_address.columns.patid == prv_demo.columns.patid)
+            .order_by(prv_address.columns.address_preferred.desc())
+            .order_by(prv_address.columns.address_period_start.desc())
+            .limit(1)
+            .correlate(prv_demo)
         )
+
+        query = select([prv_demo, prv_address]).filter(
+            prv_address.columns.addressid == subquery
+        )
+        print(query.compile(engine))
 
         return query
 

--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -155,7 +155,7 @@ def get_query(engine, version, args):
 
         query = select([prv_demo, prv_address]).filter(
             prv_demo.columns.patid == prv_address.columns.patid,
-            prv_address.columns.addressid == subquery
+            prv_address.columns.addressid == subquery,
         )
 
         return query

--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -155,7 +155,6 @@ def get_query(engine, version, args):
         query = select([prv_demo, prv_address]).filter(
             prv_address.columns.addressid == subquery
         )
-        print(query.compile(engine))
 
         return query
 


### PR DESCRIPTION
Only one change amounting to one additional line in get_query(), but it will ensure that each row returned has a distinct value for patid on the private_address_history table

For [ticket #182873034](https://www.pivotaltracker.com/story/show/182873034)