### PR TITLE
changed extracted format in `handle_row()` within `extract.py` to output dob as YYYY-MM-DD instead of ISO format

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -233,7 +233,7 @@ def handle_row(row, report, version):
     output_row.append(clean_string(family_name))
 
     dob = case_insensitive_lookup(row, "DOB", version)
-    output_row.append(dob.isoformat())
+    output_row.append(dob.strftime("%Y-%m-%d"))
 
     sex = case_insensitive_lookup(row, "sex", version)
     validate(report, "sex", sex)


### PR DESCRIPTION
Just one line diff to swap outputting the DoB `datetime` object with a set YYYY-MM-DD format ("%Y-%m-%d"), where the previous code had `.isoformat()` as its output.

For [ticket #183688204](https://www.pivotaltracker.com/story/show/183688204)
