### PR TITLE
adds separate garble time to metadata file

### DIFF
--- a/garble.py
+++ b/garble.py
@@ -4,7 +4,6 @@ import argparse
 import glob
 import json
 import os
-import shutil
 import subprocess
 import sys
 from datetime import datetime

--- a/garble.py
+++ b/garble.py
@@ -104,7 +104,10 @@ def garble_pii(args):
         source_timestamp == meta_timestamp
     ), "Metadata creation date does not match pii file timestamp"
 
-    shutil.copyfile(metadata_file, Path("output") / metadata_file_name)
+    metadata["garble_time"] = datetime.now().isoformat()
+
+    with open(Path("output") / metadata_file_name, "w+") as metafile:
+        json.dump(metadata, metafile, indent=2)
 
     secret = validate_secret_file(secret_file)
     individuals_secret = derive_subkey(secret, "individuals")

--- a/households.py
+++ b/households.py
@@ -309,16 +309,17 @@ def create_output_zip(args, n_households, household_time):
 
     metadata["number_of_households"] = n_households
 
+    metadata["household_garble_time"] = household_time.isoformat()
+
     if not args.householddef:
-        metadata["household_inference_time"] = household_time.isoformat()
         metadata["households_inferred"] = True
     else:
         metadata["households_inferred"] = False
 
-    with open(Path("temp-data") / new_metadata_filename, "w") as metadata_file:
+    with open(Path("temp-data") / new_metadata_filename, "w+") as metadata_file:
         json.dump(metadata, metadata_file, indent=2)
 
-    with open(Path("output") / new_metadata_filename, "w") as metadata_file:
+    with open(Path("output") / new_metadata_filename, "w+") as metadata_file:
         json.dump(metadata, metadata_file, indent=2)
 
     with ZipFile(Path(args.outputfile), "w") as garbled_zip:


### PR DESCRIPTION
adds a garble time, supplied when `garble.py` (or a household garble time if `households.py` is run) to the metadata files produced in the extracting/garbling process. Useful for verification by linkage agent. For [ticket #183724475](https://www.pivotaltracker.com/story/show/183724475)