### PR TITLE
Fix data characterization script

### DIFF
--- a/data_analysis.py
+++ b/data_analysis.py
@@ -189,7 +189,7 @@ def summary(series):
     # list_chars is a list of lists e.g: [[J,o,h,n],[J,a,n,e],...]
     flat_list = [item for sublist in list_chars.tolist() for item in sublist]
     # flat_list is now a single list [J,o,h,n,J,a,n,e,....]
-    total_chars = pd.Series(flat_list).value_counts().to_dict()
+    total_chars = pd.Series(flat_list, dtype=str).value_counts().to_dict()
 
     return {"missing": int(missing), "length": length, "characters": total_chars}
 

--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -119,7 +119,7 @@ def case_insensitive_lookup(row, key, version):
             mapped_subkey = map_key(row, subkey)
             if mapped_subkey:
                 subdata = empty_str_from_none(row[mapped_subkey])
-                data = (data + " " + subdata)
+                data = data + " " + subdata
 
         return data
 

--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -107,23 +107,25 @@ def empty_str_from_none(string):
     if string is None:
         return ""
     else:
-        return str(string)
+        return string
 
 
 def case_insensitive_lookup(row, key, version):
     data_key = DATA_DICTIONARY[version][key]
-    data = ""
-    if type(data_key) == list:
-        for subkey in data_key:
+    if isinstance(data_key, list):
+        first_key = map_key(row, data_key[0])
+        data = empty_str_from_none(row[first_key])
+        for subkey in data_key[1:]:
             mapped_subkey = map_key(row, subkey)
             if mapped_subkey:
                 subdata = empty_str_from_none(row[mapped_subkey])
-                data = " ".join([data, subdata]).strip()
+                data = (data + " " + subdata)
+
+        return data
+
     else:
         mapped_key = map_key(row, data_key)
-        if mapped_key:
-            data = row[mapped_key]
-    return data if (data != "") else None
+        return row[mapped_key] if mapped_key else None
 
 
 def translation_lookup(row, key, translation_map):


### PR DESCRIPTION
Some recent changes broke the data characterization script, users were getting the following error when running against a DB or a CSV:

```
$ py data_analysis.py -s v2 --db postgresql://codi:codi@localhost/final_site_d
Traceback (most recent call last):
  File "/Users/dehall/data-owner-tools-review/data_analysis.py", line 207, in <module>
    results = analyze(db_data, args.schema)
  File "/Users/dehall/data-owner-tools-review/data_analysis.py", line 41, in analyze
    record_id_col = case_insensitive_lookup(data, "record_id", source)
  File "/Users/dehall/data-owner-tools-review/utils/data_reader.py", line 126, in case_insensitive_lookup
    return data if (data != "") else None
  File "/usr/local/lib/python3.9/site-packages/pandas/core/generic.py", line 1537, in __nonzero__
    raise ValueError(
ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

This PR tweaks the `case_insensitive_lookup` function to better support being called from `data_analysis.py`. It should still work fine when called from `extract.py`.  The key difference is that when called from data_analysis, `row` is a pandas DataFrame, and `row[key]` is a pandas Series, as compared to from extract, where `row` is a plain dict, and `row[key]` is a string. The changes here should allow for concatenating either two strings or two Series of strings -- specifically the `+` operator works on both.

The change to `data_analysis.py` is to prevent this warning:
```
data_analysis.py:193: DeprecationWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
```