### PR TITLE
Timestamp Standardization Re-Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ To map the LINK_IDs back to PATIDs, use the `linkid_to_patid.py` script. The scr
 
 1. The path to the pii-timestamp.csv file. 
 2. The path to the LINK_ID CSV file provided by the linkage agent
-3. The path to the household pii CSV file, either provided by the data owner directly or inferred by the `households.py` script (which by default is named `household_pii-timestamp.csv`)
+3. The path to the household pii CSV file, either provided by the data owner directly or inferred by the `households.py` script (which by default is named `household_pii-TIMESTAMP.csv`)
 4. The path to the HOUSEHOLDID CSV file provided by the linkage agent if you provided household information
 
 If both the pii-timestamp.csv and LINK_ID CSV file are provided as arguments, the script will create a file called `linkid_to_patid.csv` with the mapping of LINK_IDs to PATIDs in the `output/` folder by default. If both the household pii-timestamp.csv and LINK_ID CSV file are provided as arguments this will also create a `householdid_to_patid.csv` file in the `output/` folder.

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The metadata created by the garbling process is used to validate the metadata re
 ```
 python utils\validate_metadata.py <path-to-garbled.zip> <path-to-result.zip>
 ```
-So, assuming that the output of `garble.py` is a file, `garble.zip` located in the `output` directory, and assuming that the results from the linkage agent are received as a zip archive named `results.zip` located in the `inbox` directory, the syntax would be
+So, assuming that the output of `garble.py` is a file, `garble.zip` located in the `output` directory, and that the results from the linkage agent are received as a zip archive named `results.zip` located in the `inbox` directory, the syntax would be
 ```
 python utils\validate_metadata.py output\garble.py inbox\results.zip
 ```

--- a/definitions.py
+++ b/definitions.py
@@ -1,1 +1,4 @@
+import datetime
+
 TIMESTAMP_FMT = "%Y%m%dT%H%M%S"
+TIMESTAMP_LEN = len(datetime.datetime.now().strftime(TIMESTAMP_FMT))

--- a/definitions.py
+++ b/definitions.py
@@ -1,0 +1,1 @@
+TIMESTAMP_FMT = "%Y%m%dT%H%M%S"

--- a/extract.py
+++ b/extract.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from random import shuffle
 from time import strftime, strptime
 
+from definitions import TIMESTAMP_FMT
 from sqlalchemy import create_engine
 
-from utils.constants import timestamp_fmt_str
 from utils.data_reader import (
     add_parser_db_args,
     case_insensitive_lookup,
@@ -36,8 +36,6 @@ HEADER = [
 
 V1 = "v1"
 V2 = "v2"
-
-TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():

--- a/extract.py
+++ b/extract.py
@@ -14,6 +14,7 @@ from time import strftime, strptime
 
 from sqlalchemy import create_engine
 
+from utils.constants import timestamp_fmt_str
 from utils.data_reader import (
     add_parser_db_args,
     case_insensitive_lookup,
@@ -35,6 +36,8 @@ HEADER = [
 
 V1 = "v1"
 V2 = "v2"
+
+TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():
@@ -260,7 +263,7 @@ def write_metadata(n_rows, creation_time):
         "creation_date": creation_time.isoformat(),
         "uuid1": str(uuid.uuid1()),
     }
-    timestamp = datetime.strftime(creation_time, "%Y%m%dT%H%M%S")
+    timestamp = datetime.strftime(creation_time, TIMESTAMP_FMT)
     metaname = Path("temp-data") / f"metadata-{timestamp}.json"
     with open(metaname, "w", newline="", encoding="utf-8") as metafile:
         json.dump(metadata, metafile, indent=2)
@@ -268,7 +271,7 @@ def write_metadata(n_rows, creation_time):
 
 def write_data(output_rows, args):
     creation_time = datetime.now()
-    timestamp = datetime.strftime(creation_time, "%Y%m%dT%H%M%S")
+    timestamp = datetime.strftime(creation_time, TIMESTAMP_FMT)
     os.makedirs("temp-data", exist_ok=True)
     csvname = f"temp-data/pii-{timestamp}.csv"
     with open(csvname, "w", newline="", encoding="utf-8") as csvfile:

--- a/extract.py
+++ b/extract.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from random import shuffle
 from time import strftime, strptime
 
-from definitions import TIMESTAMP_FMT
 from sqlalchemy import create_engine
 
+from definitions import TIMESTAMP_FMT
 from utils.data_reader import (
     add_parser_db_args,
     case_insensitive_lookup,

--- a/extract.py
+++ b/extract.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from random import shuffle
 from time import strftime, strptime
+
 from sqlalchemy import create_engine
 
 from definitions import TIMESTAMP_FMT

--- a/extract.py
+++ b/extract.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from pathlib import Path
 from random import shuffle
 from time import strftime, strptime
-
 from sqlalchemy import create_engine
 
 from definitions import TIMESTAMP_FMT

--- a/garble.py
+++ b/garble.py
@@ -9,13 +9,11 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from utils import constants
 from zipfile import ZipFile
 
 from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 
-TIMESTAMP_FMT = constants.timestamp_fmt_str
 
 
 def parse_arguments():

--- a/garble.py
+++ b/garble.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from zipfile import ZipFile
 
-from definitions import TIMESTAMP_FMT
+from definitions import TIMESTAMP_FMT, TIMESTAMP_LEN
 from derive_subkey import derive_subkey
 
 
@@ -79,7 +79,7 @@ def garble_pii(args):
         source_file = Path(args.sourcefile)
     else:
         filenames = list(
-            filter(lambda x: "pii" in x and len(x) == 23, os.listdir("temp-data"))
+            filter(lambda x: "pii" in x and len(x) == 8 + TIMESTAMP_LEN, os.listdir("temp-data"))
         )
         timestamps = [
             datetime.strptime(filename[4:-4], TIMESTAMP_FMT) for filename in filenames

--- a/garble.py
+++ b/garble.py
@@ -9,9 +9,12 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+from utils import constants
 from zipfile import ZipFile
 
 from derive_subkey import derive_subkey
+
+TIMESTAMP_FMT = constants.timestamp_fmt_str
 
 
 def parse_arguments():
@@ -81,7 +84,7 @@ def garble_pii(args):
             filter(lambda x: "pii" in x and len(x) == 23, os.listdir("temp-data"))
         )
         timestamps = [
-            datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S") for filename in filenames
+            datetime.strptime(filename[4:-4], TIMESTAMP_FMT) for filename in filenames
         ]
         newest_name = filenames[timestamps.index(max(timestamps))]
         source_file = Path("temp-data") / newest_name

--- a/garble.py
+++ b/garble.py
@@ -79,7 +79,10 @@ def garble_pii(args):
         source_file = Path(args.sourcefile)
     else:
         filenames = list(
-            filter(lambda x: "pii" in x and len(x) == 8 + TIMESTAMP_LEN, os.listdir("temp-data"))
+            filter(
+                lambda x: "pii" in x and len(x) == 8 + TIMESTAMP_LEN,
+                os.listdir("temp-data"),
+            )
         )
         timestamps = [
             datetime.strptime(filename[4:-4], TIMESTAMP_FMT) for filename in filenames

--- a/garble.py
+++ b/garble.py
@@ -9,10 +9,13 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+from utils import constants
 from zipfile import ZipFile
 
 from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
+
+TIMESTAMP_FMT = constants.timestamp_fmt_str
 
 
 def parse_arguments():

--- a/garble.py
+++ b/garble.py
@@ -9,12 +9,11 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from utils import constants
 from zipfile import ZipFile
 
+from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 
-TIMESTAMP_FMT = constants.timestamp_fmt_str
 
 
 def parse_arguments():

--- a/garble.py
+++ b/garble.py
@@ -15,7 +15,6 @@ from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 
 
-
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Tool for garbling PII in for PPRL purposes in the CODI project"

--- a/households.py
+++ b/households.py
@@ -15,6 +15,7 @@ import pandas as pd
 
 from derive_subkey import derive_subkey
 from households.matching import addr_parse, get_houshold_matches
+from utils.constants import timestamp_fmt_str
 
 HEADERS = ["HOUSEHOLD_POSITION", "PII_POSITIONS"]
 HOUSEHOLD_PII_HEADERS = [
@@ -25,6 +26,8 @@ HOUSEHOLD_PII_HEADERS = [
     "record_ids",
 ]
 HOUSEHOLD_POS_PID_HEADERS = ["household_position", "pid"]
+
+TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():
@@ -121,7 +124,7 @@ def parse_source_file(source_file):
 
 def write_households_pii(output_rows, household_time):
     shuffle(output_rows)
-    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
+    timestamp = household_time.strftime(TIMESTAMP_FMT)
     with open(
         Path("temp-data") / f"households_pii-{timestamp}.csv",
         "w",
@@ -159,7 +162,7 @@ def bfs_traverse_matches(pos_to_pairs, position):
 def get_default_pii_csv(dirname="temp-data"):
     filenames = list(filter(lambda x: "pii" in x and len(x) == 23, os.listdir(dirname)))
     timestamps = [
-        datetime.strptime(filename[4:-4], "%Y%m%dT%H%M%S") for filename in filenames
+        datetime.strptime(filename[4:-4], TIMESTAMP_FMT) for filename in filenames
     ]
     newest_name = filenames[timestamps.index(max(timestamps))]
     source_file = Path("temp-data") / newest_name
@@ -240,7 +243,7 @@ def write_hid_hh_pos_map(pos_pid_rows):
 
 
 def hash_households(args, household_time):
-    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
+    timestamp = household_time.strftime(TIMESTAMP_FMT)
     schema_file = Path(args.schemafile)
     secret_file = Path(args.secretfile)
     secret = validate_secret_file(secret_file)
@@ -283,7 +286,7 @@ def infer_households(args, household_time):
 
 def create_output_zip(args, n_households, household_time):
 
-    timestamp = household_time.strftime("%Y%m%dT%H%M%S")
+    timestamp = household_time.strftime(TIMESTAMP_FMT)
 
     if args.sourcefile:
         source_file = Path(args.sourcefile)

--- a/households.py
+++ b/households.py
@@ -16,7 +16,6 @@ import pandas as pd
 from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 from households.matching import addr_parse, get_houshold_matches
-from utils.constants import timestamp_fmt_str
 
 HEADERS = ["HOUSEHOLD_POSITION", "PII_POSITIONS"]
 HOUSEHOLD_PII_HEADERS = [
@@ -27,8 +26,6 @@ HOUSEHOLD_PII_HEADERS = [
     "record_ids",
 ]
 HOUSEHOLD_POS_PID_HEADERS = ["household_position", "pid"]
-
-TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():

--- a/households.py
+++ b/households.py
@@ -13,9 +13,9 @@ from zipfile import ZipFile
 
 import pandas as pd
 
+from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 from households.matching import addr_parse, get_houshold_matches
-from utils.constants import timestamp_fmt_str
 
 HEADERS = ["HOUSEHOLD_POSITION", "PII_POSITIONS"]
 HOUSEHOLD_PII_HEADERS = [
@@ -26,8 +26,6 @@ HOUSEHOLD_PII_HEADERS = [
     "record_ids",
 ]
 HOUSEHOLD_POS_PID_HEADERS = ["household_position", "pid"]
-
-TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():

--- a/households.py
+++ b/households.py
@@ -16,6 +16,7 @@ import pandas as pd
 from definitions import TIMESTAMP_FMT
 from derive_subkey import derive_subkey
 from households.matching import addr_parse, get_houshold_matches
+from utils.constants import timestamp_fmt_str
 
 HEADERS = ["HOUSEHOLD_POSITION", "PII_POSITIONS"]
 HOUSEHOLD_PII_HEADERS = [
@@ -26,6 +27,8 @@ HOUSEHOLD_PII_HEADERS = [
     "record_ids",
 ]
 HOUSEHOLD_POS_PID_HEADERS = ["household_position", "pid"]
+
+TIMESTAMP_FMT = timestamp_fmt_str
 
 
 def parse_arguments():

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -20,7 +20,7 @@ def parse_arguments():
         description="Tool for translating LINK_IDs back into PATIDs"
     )
     parser.add_argument("--sourcefile", help="Source pii-TIMESTAMP.csv file")
-    parser.add_argument("--linkszip", help="LINK_ID CSV file from linkage agent")
+    parser.add_argument("--linkszip", help="LINK_ID ZIP file from linkage agent")
     parser.add_argument(
         "--hhsourcefile",
         help="Household PII csv, either inferred by households.py"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,1 +1,0 @@
-timestamp_fmt_str = "%Y%m%dT%H%M%S"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,1 @@
+timestamp_fmt_str = "%Y%m%dT%H%M%S"


### PR DESCRIPTION
This is a cleaned up version of PR #38, removing the superfluous commit messages. The original PR description is reproduced below: 

Standardized the timestamp format used in canonical file naming by adding a definitions.py file that defines it. This doesn't change much, but if we choose to change the time stamp convention doing so will be much simpler.

see sister PR https://github.com/mitre/linkage-agent-tools/pull/31

In completion of [ticket #183428340](https://www.pivotaltracker.com/story/show/183428340)