### PR TITLE
added flag to ignore validation issues in `linkid_to_patid.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,9 @@ To map the LINK_IDs back to PATIDs, use the `linkid_to_patid.py` script. The scr
 3. The path to the household pii CSV file, either provided by the data owner directly or inferred by the `households.py` script (which by default is named `household_pii-TIMESTAMP.csv`)
 4. The path to the HOUSEHOLDID CSV file provided by the linkage agent if you provided household information
 
-If both the pii-timestamp.csv and LINK_ID CSV file are provided as arguments, the script will create a file called `linkid_to_patid.csv` with the mapping of LINK_IDs to PATIDs in the `output/` folder by default. If both the household pii-timestamp.csv and LINK_ID CSV file are provided as arguments this will also create a `householdid_to_patid.csv` file in the `output/` folder.
+* If both the pii-timestamp.csv and LINK_ID CSV file are provided as arguments, the script will create a file called `linkid_to_patid.csv` with the mapping of LINK_IDs to PATIDs in the `output/` folder by default. If both the household pii-timestamp.csv and LINK_ID CSV file are provided as arguments this will also create a `householdid_to_patid.csv` file in the `output/` folder.
+
+* `linkid_to_patid.py` also supports an option (`--force` or `-f`) to ignore the results of the the metadata validation should they yield any issues. **_WARNING_: THIS SHOULD ONLY BE USED AS A LAST RESORT SHOULD DATA OWNERS BE CERTAIN THEY WISH TO PERFORM PATIENT MAPPING ON TWO SETS OF DATA DEEMED INVALID BY THE VALIDATION SCRIPTS.**
 
 ### [Optional] Independently Validate Result Metadata
 

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -142,16 +142,18 @@ def translate_linkids(args):
             source_name=source_metadata_filename,
             linkage_name=args.linkszip,
         )
-        if len(metadata_issues) == 0:
-            write_patid_links(args)
-        else:
+        if len(metadata_issues) > 0:
             print(
-                f"ERROR: Inconsistencies found in "
-                f"source metadata file {args.sourcefile}"
+                f"{'ERROR' if args.force else 'WARNING'}: "
+                f"Inconsistencies found in source "
+                f"metadata file {args.sourcefile}"
                 f" and linkage archive metadata in {args.linkszip}:"
             )
             for issue in metadata_issues:
                 print("\t" + issue)
+
+        if len(metadata_issues) == 0 or args.force:
+            write_patid_links(args)
 
     if args.hhlinkszip and args.hhsourcefile:
         source_metadata_filename = Path(args.hhsourcefile).parent / Path(
@@ -166,27 +168,17 @@ def translate_linkids(args):
             source_name=source_metadata_filename,
             linkage_name=args.hhlinkszip,
         )
-        if not args.force:
-            if len(metadata_issues) == 0:
-                write_hh_links(args)
-                return
-            else:
-                print(
-                    f"ERROR: Inconsistencies found in source "
-                    f"metadata file {args.sourcefile}"
-                    f" and linkage archive metadata in {args.linkszip}:"
-                )
-                for issue in metadata_issues:
-                    print("\t" + issue)
-                return
-        else:
-            if len(metadata_issues) > 0:
-                print(
-                    f"WARNING: Inconsistencies found in source "
-                    f"metadata file {args.sourcefile}"
-                    f" and linkage archive metadata in {args.linkszip}."
-                    f"Proceeding anyway (this may yield meaningless data)"
-                )
+        if len(metadata_issues) > 0:
+            print(
+                f"{'ERROR' if args.force else 'WARNING'}: "
+                f"Inconsistencies found in source "
+                f"metadata file {args.sourcefile}"
+                f" and linkage archive metadata in {args.linkszip}:"
+            )
+            for issue in metadata_issues:
+                print("\t" + issue)
+
+        if len(metadata_issues) == 0 or args.force:
             write_hh_links(args)
 
 

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -144,7 +144,7 @@ def translate_linkids(args):
         )
         if len(metadata_issues) > 0:
             print(
-                f"{'ERROR' if args.force else 'WARNING'}: "
+                f"{'WARNING' if args.force else 'ERROR'}: "
                 f"Inconsistencies found in source "
                 f"metadata file {args.sourcefile}"
                 f" and linkage archive metadata in {args.linkszip}:"
@@ -170,7 +170,7 @@ def translate_linkids(args):
         )
         if len(metadata_issues) > 0:
             print(
-                f"{'ERROR' if args.force else 'WARNING'}: "
+                f"{'WARNING' if args.force else 'ERROR'}: "
                 f"Inconsistencies found in source "
                 f"metadata file {args.sourcefile}"
                 f" and linkage archive metadata in {args.linkszip}:"

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -39,13 +39,13 @@ def parse_arguments():
     )
     parser.add_argument(
         "--force",
-        'f',
+        "-f",
         dest="force",
-        action='store_true',
+        action="store_true",
         default=False,
         nargs="?",
         help="Attempt resolution of patids from linkids even if issues are found"
-             "in metadata file. USE ONLY AS LAST RESORT"
+        "in metadata file. USE ONLY AS LAST RESORT",
     )
     args = parser.parse_args()
     return args

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -37,6 +37,16 @@ def parse_arguments():
         default="output",
         help="Specify an output directory for links. Default is './output'",
     )
+    parser.add_argument(
+        "--force",
+        'f',
+        dest="force",
+        action='store_true',
+        default=False,
+        nargs="?",
+        help="Attempt resolution of patids from linkids even if issues are found"
+             "in metadata file. USE ONLY AS LAST RESORT"
+    )
     args = parser.parse_args()
     return args
 
@@ -157,16 +167,28 @@ def translate_linkids(args):
             source_name=source_metadata_filename,
             linkage_name=args.hhlinkszip,
         )
-        if len(metadata_issues) == 0:
-            write_hh_links(args)
+        if not args.force:
+            if len(metadata_issues) == 0:
+                write_hh_links(args)
+                return
+            else:
+                print(
+                    f"ERROR: Inconsistencies found in source "
+                    f"metadata file {args.sourcefile}"
+                    f" and linkage archive metadata in {args.linkszip}:"
+                )
+                for issue in metadata_issues:
+                    print("\t" + issue)
+                return
         else:
-            print(
-                f"ERROR: Inconsistencies found in source "
-                f"metadata file {args.sourcefile}"
-                f" and linkage archive metadata in {args.linkszip}:"
-            )
-            for issue in metadata_issues:
-                print("\t" + issue)
+            if len(metadata_issues) > 0:
+                print(
+                    f"WARNING: Inconsistencies found in source "
+                    f"metadata file {args.sourcefile}"
+                    f" and linkage archive metadata in {args.linkszip}."
+                    f"Proceeding anyway (this may yield meaningless data)"
+                )
+            write_hh_links(args)
 
 
 def main():

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -43,7 +43,6 @@ def parse_arguments():
         dest="force",
         action="store_true",
         default=False,
-        nargs="?",
         help="Attempt resolution of patids from linkids even if issues are found"
         "in metadata file. USE ONLY AS LAST RESORT",
     )


### PR DESCRIPTION
Added a `--force` or `-f` flag which ignores issues found by metadata validation. If the option is specified and issues are found, it will give a warning that the user probably shouldn't be doing this, but will not list the issues found.

For ticket [no. 183864643](https://www.pivotaltracker.com/story/show/183864643)