### PR TITLE
Strip whitespace from salt file

### DIFF
--- a/garble.py
+++ b/garble.py
@@ -48,7 +48,9 @@ def parse_arguments():
 def validate_secret_file(secret_file):
     secret = None
     with open(secret_file, "r") as secret_text:
-        secret = secret_text.read()
+        # strip whitespace just in case someone copy & pastes the salt text
+        #  instead of the file itself (eg, trim extra newline)
+        secret = secret_text.read().strip()
         try:
             int(secret, 16)
         except ValueError:

--- a/households.py
+++ b/households.py
@@ -81,7 +81,7 @@ def parse_arguments():
 def validate_secret_file(secret_file):
     secret = None
     with open(secret_file, "r") as secret_text:
-        secret = secret_text.read()
+        secret = secret_text.read().strip()
         try:
             int(secret, 16)
         except ValueError:


### PR DESCRIPTION
Quick addition to strip whitespace from the salt file just in case a user copy & pastes the salt text into a file, instead of using a provided salt file directly

A complete test would run through the entire sequence with one set of data garbled with a salt without a space, and one set of data garbled with a salt with a space, but a quick test is just to garble the same data twice with those 2 salts and confirm the results are identical:

```
MM272574-PC:data-owner-tools-review dehall$ python3 garble.py temp-data/site_a/pii-20221202T081742.csv ./example-schema/ deidentification_secret.txt
CLK data written to output/name-sex-dob-phone.json
CLK data written to output/name-sex-dob-zip.json
CLK data written to output/name-sex-dob-addr.json
Zip file created at: output/garbled.zip
MM272574-PC:data-owner-tools-review dehall$ ls output/
garbled.zip		name-sex-dob-addr.json	name-sex-dob-phone.json	name-sex-dob-zip.json
MM272574-PC:data-owner-tools-review dehall$ mv output/name-sex-dob-addr.json output/name-sex-dob-addr-before-space.json
MM272574-PC:data-owner-tools-review dehall$ python3 garble.py temp-data/site_a/pii-20221202T081742.csv ./example-schema/ deidentification_secret_with_space.txt
CLK data written to output/name-sex-dob-phone.json
CLK data written to output/name-sex-dob-zip.json
CLK data written to output/name-sex-dob-addr.json
Zip file created at: output/garbled.zip
MM272574-PC:data-owner-tools-review dehall$ ls output/
garbled.zip				name-sex-dob-addr-before-space.json	name-sex-dob-addr.json			name-sex-dob-phone.json			name-sex-dob-zip.json
MM272574-PC:data-owner-tools-review dehall$ mv output/name-sex-dob-addr.json output/name-sex-dob-addr-with-space.json
MM272574-PC:data-owner-tools-review dehall$ diff output/name-sex-dob-addr-before-space.json output/name-sex-dob-addr-with-space.json
MM272574-PC:data-owner-tools-review dehall$ diff deidentification_secret.txt deidentification_secret_with_space.txt
1c1,2
< 7f6bc58fd583035b3eda3ffc941f85add7bf08dcf4966b4fcb5c886b9ad2f7bf
\ No newline at end of file
---
> 7f6bc58fd583035b3eda3ffc941f85add7bf08dcf4966b4fcb5c886b9ad2f7bf
>
\ No newline at end of file
MM272574-PC:data-owner-tools-review dehall$

```