### PR TITLE
Additional tweaks to improve performance of household inference

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ clkhash>=0.16.0
 psycopg2>=2.8.3
 anonlink-client==0.1.5
 ijson>=3.1.2
-textdistance>=4.2.1
+textdistance[extras]>=4.5.0
 usaddress>=0.5.10
 pylint>=2.4.2
 tqdm>=4.36.1


### PR DESCRIPTION
This PR introduces yet more tweaks to improve performance of household inference in `households.py`.

Summary:

 - Only read the pii columns required
 - Keep the "exploded address" columns in a separate DataFrame so we can delete the whole thing once those columns are no longer needed
 - Dump the household matched pairs to a file so that we can restart from there if the process runs out of memory
 - Add a `--pairsfile` arg to specify that pairs file to restart from there
 - Write the household_pii and mapping files at the same time, don't just store the household_pii file in an array to write later
 - Add some additional debug statements
 - Keep using MultiIndexes wherever possible rather than converting to lists of tuples because the performance seems to be better all around
 - Add the `[extras]` to the textdistance dependency because it includes additional libraries that speed up, ex, jarowinkler. In my testing this was about a 25% speedup.
 - Delete objects and aggressively GC when they are no longer needed