### PR TITLE
Additional households fixes based on testing

### DIFF
--- a/households.py
+++ b/households.py
@@ -76,6 +76,17 @@ def parse_arguments():
         " may increase runtime. Default is 4",
     )
     parser.add_argument(
+        "--fast_addresses",
+        action="store_true",
+        help="Use a faster but lower quality method for address comparison."
+        " By default the inference process will split up addresses into"
+        " street, number, suffix, etc, but this increases memory & runtime."
+        " Enabling this feature causes the process to use the entire address"
+        " as a single string for comparisons. If addresses have not been"
+        " standardized/validated, this setting will increase false negatives"
+        " (records not being included in households where they should be).",
+    )
+    parser.add_argument(
         "--pairsfile",
         help="Location of matching pairs file",
     )
@@ -179,7 +190,7 @@ def write_pii_and_mapping_file(pos_pid_rows, hid_pat_id_rows, household_time, ar
     # so it can be traversed sort of like a graph from any given patient
     # note the key is patient position within the pii_lines dataframe
     pos_to_pairs = get_household_matches(
-        pii_lines, args.split_factor, args.debug, args.pairsfile
+        pii_lines, args.split_factor, args.debug, args.fast_addresses, args.pairsfile
     )
 
     mapping_file = Path(args.mappingfile)

--- a/households.py
+++ b/households.py
@@ -76,15 +76,17 @@ def parse_arguments():
         " may increase runtime. Default is 4",
     )
     parser.add_argument(
-        "--fast_addresses",
+        "--exact_addresses",
         action="store_true",
-        help="Use a faster but lower quality method for address comparison."
+        help="Use exact matches on address as the definition of a household."
         " By default the inference process will split up addresses into"
-        " street, number, suffix, etc, but this increases memory & runtime."
+        " street, number, suffix, etc, and considers phone # and family name"
+        " when making a determination which records belong to which household."
         " Enabling this feature causes the process to use the entire address"
-        " as a single string for comparisons. If addresses have not been"
-        " standardized/validated, this setting will increase false negatives"
-        " (records not being included in households where they should be).",
+        " as a single string for comparisons, and only the address. "
+        " If addresses have not been standardized/validated, this setting"
+        " will likely increase false negatives  (records not being included "
+        " in households where they should be).",
     )
     parser.add_argument(
         "--pairsfile",
@@ -190,7 +192,7 @@ def write_pii_and_mapping_file(pos_pid_rows, hid_pat_id_rows, household_time, ar
     # so it can be traversed sort of like a graph from any given patient
     # note the key is patient position within the pii_lines dataframe
     pos_to_pairs = get_household_matches(
-        pii_lines, args.split_factor, args.debug, args.fast_addresses, args.pairsfile
+        pii_lines, args.split_factor, args.debug, args.exact_addresses, args.pairsfile
     )
 
     mapping_file = Path(args.mappingfile)

--- a/households.py
+++ b/households.py
@@ -209,10 +209,10 @@ def write_pii_and_mapping_file(pos_pid_rows, hid_pat_id_rows, household_time, ar
             lines_processed = 0
             five_percent = int(len(pii_lines) / 20)
             # Match households
-            for position, line in pii_lines.sample(frac=1).iterrows():
+            for position, _line in pii_lines.sample(frac=1).iterrows():
                 # sample(frac=1) shuffles the entire dataframe
                 # note that "position" is the index and still relative to the original
-
+                line = pii_lines.loc[position]
                 lines_processed += 1
 
                 if args.debug and (lines_processed % five_percent) == 0:
@@ -223,7 +223,6 @@ def write_pii_and_mapping_file(pos_pid_rows, hid_pat_id_rows, household_time, ar
 
                 if line["written_to_file"]:
                     continue
-                line["written_to_file"] = True
 
                 if position in pos_to_pairs:
                     pat_positions = bfs_traverse_matches(pos_to_pairs, position)
@@ -231,11 +230,12 @@ def write_pii_and_mapping_file(pos_pid_rows, hid_pat_id_rows, household_time, ar
                     pat_ids = list(
                         map(lambda p: pii_lines.at[p, "record_id"], pat_positions)
                     )
-                    # mark all these rows as written to file
-                    pii_lines.loc[pat_positions, ["written_to_file"]] = True
                 else:
                     pat_positions = [position]
                     pat_ids = [line[0]]
+
+                # mark all these rows as written to file
+                pii_lines.loc[pat_positions, ["written_to_file"]] = True
 
                 string_pat_positions = [str(p) for p in pat_positions]
                 pat_string = ",".join(string_pat_positions)

--- a/households.py
+++ b/households.py
@@ -218,6 +218,7 @@ def write_pii_and_mapping_file(pos_pid_rows, hid_pat_id_rows, household_time, ar
             pii_lines["written_to_file"] = False
             hclk_position = 0
             lines_processed = 0
+            hh_sizes = []
             five_percent = int(len(pii_lines) / 20)
             # Match households
             for position, _line in pii_lines.sample(frac=1).iterrows():
@@ -248,6 +249,8 @@ def write_pii_and_mapping_file(pos_pid_rows, hid_pat_id_rows, household_time, ar
                 # mark all these rows as written to file
                 pii_lines.loc[pat_positions, ["written_to_file"]] = True
 
+                hh_sizes.append(len(pat_positions))
+
                 string_pat_positions = [str(p) for p in pat_positions]
                 pat_string = ",".join(string_pat_positions)
                 mapping_writer.writerow([hclk_position, pat_string])
@@ -269,6 +272,12 @@ def write_pii_and_mapping_file(pos_pid_rows, hid_pat_id_rows, household_time, ar
                 ]
                 hclk_position += 1
                 pii_writer.writerow(output_row)
+
+    hh_sizes_series = pd.Series(hh_sizes, dtype=int)
+
+    print("Household size stats:")
+    print(hh_sizes_series.describe())
+
     return n_households
 
 

--- a/households/matching.py
+++ b/households/matching.py
@@ -12,7 +12,7 @@ from recordlinkage.base import BaseCompareFeature
 
 from definitions import TIMESTAMP_FMT
 
-MATCH_THRESHOLD = 0.9
+MATCH_THRESHOLD = 0.85
 FN_WEIGHT = 0.2
 PHONE_WEIGHT = 0.15
 ADDR_WEIGHT = 0.4

--- a/households/matching.py
+++ b/households/matching.py
@@ -232,9 +232,7 @@ def address_distance(addr1, addr2):
     # with a 0.6 adjustment is better
     score = max(
         score,
-        textdistance.jaro_winkler(a1, a2)
-        * (weight_number + weight_street_name)
-        * 0.6,
+        textdistance.jaro_winkler(a1, a2) * (weight_number + weight_street_name) * 0.6,
     ) + (secondary_score * weight_secondary)
     return score
 
@@ -285,7 +283,9 @@ def explode_address(row):
     return parsed
 
 
-def get_household_matches(pii_lines, split_factor=4, debug=False, fast_addresses=False, pairsfile=None):
+def get_household_matches(
+    pii_lines, split_factor=4, debug=False, fast_addresses=False, pairsfile=None
+):
     if pairsfile:
         if debug:
             print(f"[{datetime.now()}] Loading matching pairs file")
@@ -310,11 +310,12 @@ def get_household_matches(pii_lines, split_factor=4, debug=False, fast_addresses
             )
             pii_lines_exploded = pd.concat([pii_lines, addr_cols], axis="columns")
 
-
         if debug:
             print(f"[{datetime.now()}] Done pre-processing PII file")
 
-        candidate_links = get_candidate_links(pii_lines_exploded, split_factor, fast_addresses, debug)
+        candidate_links = get_candidate_links(
+            pii_lines_exploded, split_factor, fast_addresses, debug
+        )
         gc.collect()
 
         matching_pairs = get_matching_pairs(

--- a/linkid_to_patid.py
+++ b/linkid_to_patid.py
@@ -61,8 +61,9 @@ def parse_source_file(source_file):
 def write_patid_links(args):
     links_archive = Path(args.linkszip)
     pii_lines = parse_source_file(args.sourcefile)
+    filepath = os.path.join(args.outputdir, "linkid_to_patid.csv")
     with open(
-        os.path.join(args.outputdir, "linkid_to_patid.csv"),
+        filepath,
         "w",
         newline="",
         encoding="utf-8",
@@ -87,13 +88,15 @@ def write_patid_links(args):
                     # The +1 accounts for the header row in spreadsheet index
                     patid = pii_lines[int(row[1]) + 1][0]
                     writer.writerow([link_id, patid])
+    print(f"Wrote {filepath}")
 
 
 def write_hh_links(args):
     hh_links_file = Path(args.hhlinkszip)
     hh_pii_lines = parse_source_file(args.hhsourcefile)
+    filepath = os.path.join(args.outputdir, "householdid_to_patid.csv")
     with open(
-        os.path.join(args.outputdir, "householdid_to_patid.csv"),
+        filepath,
         "w",
         newline="",
         encoding="utf-8",
@@ -126,6 +129,7 @@ def write_hh_links(args):
 
                     for record_id in record_ids_list:
                         writer.writerow([household_id, record_id])
+    print(f"Wrote {filepath}")
 
 
 def translate_linkids(args):


### PR DESCRIPTION
- Ensure the "written_to_file" flag is read properly
- Tweak match thresholds to reduce tumbleweeds, in particular in apartments
- Fix for referencing a None object
- Adds a new `--exact_addresses` option
  - This uses a faster but lower quality method for address comparison. By default the inference process will split up addresses into street, number, suffix, etc, and use family name and phone number, but this increases memory & runtime. Enabling this feature causes the process to use the entire address as a single string for comparisons, and only the address is considered. If addresses have not been standardized/validated, this setting will increase false negatives (records not being included in households where they should be). This is primarily intended to serve as a baseline for testing the software, but might be used in practice as a last resort.
- Prints some basic household summary stats at the end
- Also adds an extra print out at the end of linkid_to_patid of the name of the filename that was written
