### PR TITLE
Additional fixes

### DIFF
--- a/data_analysis.py
+++ b/data_analysis.py
@@ -4,6 +4,7 @@ import re
 import time
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 
 from utils.data_reader import (
@@ -155,8 +156,8 @@ def top_N(series, N=0, lower_limit=1):
 
 
 def summary(series):
-    # 1. count the number of missing (null) entries
-    missing = series.isna().sum()
+    # 1. count the number of missing (null or blank string) entries
+    missing = series.replace(r"^\s*$", np.nan, regex=True).isna().sum()
 
     # 2. basic descriptive statistics on the length of the values
     length = series.str.len().describe().to_dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ clkhash>=0.16.0
 psycopg2>=2.8.3
 anonlink-client==0.1.5
 ijson>=3.1.2
-textdistance[extras]>=4.5.0
+textdistance>=4.5.0
 usaddress>=0.5.10
 pylint>=2.4.2
 tqdm>=4.36.1

--- a/utils/data_reader.py
+++ b/utils/data_reader.py
@@ -124,14 +124,18 @@ def map_key(row, key):
                 return row_key
 
 
-def empty_str_from_none(string):
-    if string is None:
+def empty_str_from_none(obj):
+    if obj is None:
         return ""
+    elif isinstance(obj, pd.Series):
+        return obj.fillna("")
     else:
-        return string
+        return obj
 
 
 def case_insensitive_lookup(row, key, version):
+    # IMPORTANT: this function gets called from extract.py and data_analysis.py
+    # with different types for `row`
     data_key = DATA_DICTIONARY[version][key]
     if isinstance(data_key, list):
         first_key = map_key(row, data_key[0])
@@ -141,6 +145,8 @@ def case_insensitive_lookup(row, key, version):
             if mapped_subkey:
                 subdata = empty_str_from_none(row[mapped_subkey])
                 data = data + " " + subdata
+                if isinstance(data, pd.Series):
+                    data.name = key
 
         return data
 


### PR DESCRIPTION
1. Don't consider missing addresses at all in household inference. Originally the logic would strip these out at the end but one data owner revealed this could cause performance issues, so now strip them out before indexing. This means these rows will not be considered at all, and will be their own "household". At some point we should probably also consider the option of not assigning individuals a household at all.
2. Remove textdistance "extras" from requirements.txt since some users had trouble with this on windows. A note will be added to the installation instructions on the wiki that installing extras is optional
3. Fix an issue with counting addresses in data_analysis.py. The issue is related to how the code combines address_street and address_detail, since it gets called from both data_analysis.py and extract.py.
4. Count blank strings as "missing" in data_analysis
5. Wrap some values in `max(int(x), 1)` in case x is a fraction 0 < x < 1